### PR TITLE
Restart capability and offline FOM interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ This python package requires updated prerequistes:
 "scipy>=1.13.1",
 "pyyaml>=6.0",
 "matplotlib>=3.8.4",
-"argparse>=1.4.0"
+"argparse>=1.4.0",
+"h5py"
 ```
 
 ### For LLNL LC Lassen users

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -35,7 +35,7 @@
     "from lasdi.latent_space import Autoencoder, initial_condition_latent\n",
     "from lasdi.postprocess import compute_errors\n",
     "\n",
-    "filename = 'lasdi_09_11_2024_20_20.npy'"
+    "filename = 'lasdi_09_18_2024_20_51.npy'"
    ]
   },
   {
@@ -113,8 +113,7 @@
     "n_z = autoencoder_param['fc' + str(n_hidden + 1) + '_e.weight'].shape[0]\n",
     "\n",
     "autoencoder.load_state_dict(autoencoder_param)\n",
-    "Z = autoencoder.encoder(X_train)\n",
-    "coefs = sindy.calibrate(Z, physics.dt, compute_loss=False, numpy=True)\n",
+    "coefs = restart_file['trainer']['best_coefs']\n",
     "gp_dictionnary = fit_gps(param_space.train_space, coefs)\n",
     "\n",
     "n_coef = sindy.ncoefs\n",

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "d67dad03-9d76-4891-82ff-7e19d1369a24",
    "metadata": {},
    "outputs": [],
@@ -46,6 +46,7 @@
     "trainer, param_space, physics, autoencoder, sindy = initialize_trainer(config)\n",
     "\n",
     "# generate initial training/test data\n",
+    "pick_samples(trainer, config)\n",
     "run_samples(trainer, config)\n",
     "# initial training given training data\n",
     "trainer.train()\n",
@@ -77,7 +78,7 @@
    "outputs": [],
    "source": [
     "# Specify the restart file you have.\n",
-    "filename = 'lasdi_09_18_2024_20_51.npy'\n",
+    "filename = 'lasdi_10_01_2024_17_09.npy'\n",
     "\n",
     "import yaml\n",
     "from lasdi.workflow import initialize_trainer\n",
@@ -110,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "dcdac0c2",
    "metadata": {},
    "outputs": [],

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -16,13 +16,57 @@
   },
   {
    "cell_type": "markdown",
+   "id": "493f4313",
+   "metadata": {},
+   "source": [
+    "# Overall workflow and training\n",
+    "\n",
+    "Data generation/training can be performed by built-in executable `lasdi`. For this example of Burgers 1D equation, you can simply run on command-line terminal:\n",
+    "```\n",
+    "lasdi burgers1d.yml\n",
+    "```\n",
+    "\n",
+    "The workflow can be also manually constructed for those who prefer python scripts and for prototyping. Following code snippets show the high-level view of the workflow in the executable `lasdi`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ead8f2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from lasdi.workflow import initialize_trainer, run_samples, pick_samples\n",
+    "\n",
+    "cfg_file = 'burgers1d.yml'\n",
+    "with open(cfg_file, 'r') as f:\n",
+    "    config = yaml.safe_load(f)\n",
+    "\n",
+    "trainer, param_space, physics, autoencoder, sindy = initialize_trainer(config)\n",
+    "\n",
+    "# generate initial training/test data\n",
+    "run_samples(trainer, config)\n",
+    "# initial training given training data\n",
+    "trainer.train()\n",
+    "\n",
+    "while (trainer.restart_iter < trainer.max_iter):\n",
+    "    if (trainer.restart_iter <= trainer.max_greedy_iter):\n",
+    "        # perform greedy sampling to pick up new samples\n",
+    "        pick_samples(trainer, config)\n",
+    "        # update training data with newly picked samples\n",
+    "        run_samples(trainer, config)\n",
+    "\n",
+    "    # train over given training data\n",
+    "    trainer.train()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cfffced1",
    "metadata": {},
    "source": [
-    "We assume all data generation/training is complete. If not done yet, please run on the terminal:\n",
-    "```\n",
-    "lasdi burgers1d.yml\n",
-    "```"
+    "If you ran the command instead, a restart file is saved at the end of the training, which can be loaded for post-processing:"
    ]
   },
   {
@@ -32,27 +76,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lasdi.latent_space import Autoencoder, initial_condition_latent\n",
-    "from lasdi.postprocess import compute_errors\n",
+    "# Specify the restart file you have.\n",
+    "filename = 'lasdi_09_18_2024_20_51.npy'\n",
     "\n",
-    "filename = 'lasdi_09_18_2024_20_51.npy'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e1dfd2b6",
-   "metadata": {},
-   "source": [
-    "Initialize physics solver, according to the config file `burgers1d.yml`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "68f93c32",
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import yaml\n",
     "from lasdi.workflow import initialize_trainer\n",
     "from lasdi.param import ParameterSpace\n",
@@ -67,26 +93,77 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "42758da9",
+   "metadata": {},
+   "source": [
+    "# Post-processing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cf48489",
+   "metadata": {},
+   "source": [
+    "Load data for post-processing:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef6a1685",
+   "id": "dcdac0c2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lasdi.gp import fit_gps\n",
+    "coefs = trainer.best_coefs\n",
+    "X_train = trainer.X_train\n",
+    "X_test = trainer.X_test\n",
     "\n",
-    "autoencoder_param = restart_file['latent_space']['autoencoder_param']\n",
+    "param_train = param_space.train_space\n",
+    "param_grid = param_space.test_space\n",
+    "test_meshgrid = param_space.test_meshgrid\n",
+    "test_grid_sizes = param_space.test_grid_sizes\n",
+    "n_init = param_space.n_init\n",
     "\n",
+    "n_a_grid, n_w_grid = test_grid_sizes\n",
+    "a_grid, w_grid = test_meshgrid\n",
+    "\n",
+    "t_grid = physics.t_grid\n",
+    "x_grid = physics.x_grid\n",
+    "t_mesh, x_mesh = np.meshgrid(t_grid, x_grid)\n",
+    "Dt, Dx = physics.dt, physics.dx\n",
+    "\n",
+    "time_dim, space_dim = t_grid.shape[0], x_grid.shape[0]\n",
+    "\n",
+    "n_coef = sindy.ncoefs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2b6e720",
+   "metadata": {},
+   "source": [
+    "They can be also loaded directly from restart file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e796b0bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coefs = restart_file['trainer']['best_coefs']\n",
     "X_train = restart_file['trainer']['X_train']\n",
+    "X_test = restart_file['trainer']['X_test']\n",
     "\n",
     "paramspace_dict = restart_file['parameters']\n",
     "param_train = paramspace_dict['train_space']\n",
     "param_grid = paramspace_dict['test_space']\n",
     "test_meshgrid = paramspace_dict['test_meshgrid']\n",
     "test_grid_sizes = paramspace_dict['test_grid_sizes']\n",
-    "\n",
     "n_init = paramspace_dict['n_init']\n",
-    "n_samples = 20\n",
+    "\n",
     "n_a_grid, n_w_grid = test_grid_sizes\n",
     "a_grid, w_grid = test_meshgrid\n",
     "\n",
@@ -97,33 +174,38 @@
     "Dt = physics_dict['dt']\n",
     "Dx = physics_dict['dx']\n",
     "\n",
-    "# total_time = bglasdi_results['total_time']\n",
-    "# start_train_phase = bglasdi_results['start_train_phase']\n",
-    "# start_fom_phase = bglasdi_results['start_fom_phase']\n",
-    "# end_train_phase = bglasdi_results['end_train_phase']\n",
-    "# end_fom_phase = bglasdi_results['end_fom_phase']\n",
-    "\n",
-    "data_test = np.load('data/data_test.npy', allow_pickle = True).item()\n",
-    "X_test = data_test['X_test']\n",
-    "\n",
     "time_dim, space_dim = t_grid.shape[0], x_grid.shape[0]\n",
+    "n_coef = restart_file['latent_dynamics']['ncoefs']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1262a0c3",
+   "metadata": {},
+   "source": [
+    "## Gaussian-process uncertainty evaluation\n",
+    "We evaluated the uncertainties of latent dynamics coefficients over 2d parameter space, with samples from GP prediction:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef6a1685",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.gp import fit_gps\n",
+    "from lasdi.gplasdi import sample_roms, average_rom\n",
+    "from lasdi.postprocess import compute_errors\n",
+    "from lasdi.gp import eval_gp\n",
     "\n",
-    "n_hidden = len(autoencoder_param.keys()) // 4 - 1\n",
-    "hidden_units = [autoencoder_param['fc' + str(i + 1) + '_e.weight'].shape[0] for i in range(n_hidden)]\n",
-    "n_z = autoencoder_param['fc' + str(n_hidden + 1) + '_e.weight'].shape[0]\n",
+    "n_samples = 20\n",
+    "autoencoder.cpu()\n",
     "\n",
-    "autoencoder.load_state_dict(autoencoder_param)\n",
-    "coefs = restart_file['trainer']['best_coefs']\n",
     "gp_dictionnary = fit_gps(param_space.train_space, coefs)\n",
     "\n",
-    "n_coef = sindy.ncoefs\n",
-    "\n",
-    "from lasdi.gplasdi import sample_roms, average_rom\n",
     "Zis_samples = sample_roms(autoencoder, physics, sindy, gp_dictionnary, param_grid, n_samples)\n",
     "Zis_mean = average_rom(autoencoder, physics, sindy, gp_dictionnary, param_grid)\n",
-    "\n",
-    "print(Zis_mean.shape)\n",
-    "print(Zis_samples.shape)\n",
     "\n",
     "X_pred_mean = autoencoder.decoder(torch.Tensor(Zis_mean)).detach().numpy()\n",
     "X_pred_samples = autoencoder.decoder(torch.Tensor(Zis_samples)).detach().numpy()\n",
@@ -139,11 +221,15 @@
     "avg_rel_error = avg_rel_error.reshape([n_w_grid, n_a_grid]).T\n",
     "max_std = max_std.reshape([n_w_grid, n_a_grid]).T\n",
     "\n",
-    "print(avg_rel_error.shape)\n",
-    "print(max_std.shape)\n",
-    "\n",
-    "from lasdi.gp import eval_gp\n",
     "gp_pred_mean, gp_pred_std = eval_gp(gp_dictionnary, param_grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f31c964",
+   "metadata": {},
+   "source": [
+    "# Visualization"
    ]
   },
   {

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -35,8 +35,7 @@
     "from lasdi.latent_space import Autoencoder, initial_condition_latent\n",
     "from lasdi.postprocess import compute_errors\n",
     "\n",
-    "date = '08_28_2024_20_46'\n",
-    "bglasdi_results = np.load('results/bglasdi_' + date + '.npy', allow_pickle = True).item()"
+    "filename = 'lasdi_09_11_2024_20_20.npy'"
    ]
   },
   {
@@ -55,17 +54,16 @@
    "outputs": [],
    "source": [
     "import yaml\n",
-    "from lasdi.workflow import initialize_physics, initialize_latent_space, ld_dict\n",
+    "from lasdi.workflow import initialize_trainer\n",
     "from lasdi.param import ParameterSpace\n",
     "\n",
     "cfg_file = 'burgers1d.yml'\n",
     "with open(cfg_file, 'r') as f:\n",
     "    config = yaml.safe_load(f)\n",
     "\n",
-    "param_space = ParameterSpace(config)\n",
-    "physics = initialize_physics(param_space, config)\n",
-    "autoencoder = initialize_latent_space(physics, config)\n",
-    "sindy = ld_dict[config['latent_dynamics']['type']](autoencoder.n_z, physics.nt, config['latent_dynamics'])"
+    "restart_file = np.load(filename, allow_pickle=True).item()\n",
+    "\n",
+    "trainer, param_space, physics, autoencoder, sindy = initialize_trainer(config, restart_file)"
    ]
   },
   {
@@ -75,16 +73,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "autoencoder_param = bglasdi_results['autoencoder_param']\n",
+    "from lasdi.gp import fit_gps\n",
     "\n",
-    "X_train = bglasdi_results['final_X_train']\n",
-    "coefs = bglasdi_results['coefs']\n",
-    "gp_dictionnary = bglasdi_results['gp_dictionnary']\n",
-    "fd_type = bglasdi_results['latent_dynamics']['fd_type']\n",
+    "autoencoder_param = restart_file['latent_space']['autoencoder_param']\n",
     "\n",
-    "paramspace_dict = bglasdi_results['parameters']\n",
-    "param_train = paramspace_dict['final_param_train']\n",
-    "param_grid = paramspace_dict['param_grid']\n",
+    "X_train = restart_file['trainer']['X_train']\n",
+    "\n",
+    "paramspace_dict = restart_file['parameters']\n",
+    "param_train = paramspace_dict['train_space']\n",
+    "param_grid = paramspace_dict['test_space']\n",
     "test_meshgrid = paramspace_dict['test_meshgrid']\n",
     "test_grid_sizes = paramspace_dict['test_grid_sizes']\n",
     "\n",
@@ -93,7 +90,7 @@
     "n_a_grid, n_w_grid = test_grid_sizes\n",
     "a_grid, w_grid = test_meshgrid\n",
     "\n",
-    "physics_dict = bglasdi_results['physics']\n",
+    "physics_dict = restart_file['physics']\n",
     "t_grid = physics_dict['t_grid']\n",
     "x_grid = physics_dict['x_grid']\n",
     "t_mesh, x_mesh = np.meshgrid(t_grid, x_grid)\n",
@@ -116,6 +113,9 @@
     "n_z = autoencoder_param['fc' + str(n_hidden + 1) + '_e.weight'].shape[0]\n",
     "\n",
     "autoencoder.load_state_dict(autoencoder_param)\n",
+    "Z = autoencoder.encoder(X_train)\n",
+    "coefs = sindy.calibrate(Z, physics.dt, compute_loss=False, numpy=True)\n",
+    "gp_dictionnary = fit_gps(param_space.train_space, coefs)\n",
     "\n",
     "n_coef = sindy.ncoefs\n",
     "\n",

--- a/examples/burgers1d.offline.bash
+++ b/examples/burgers1d.offline.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+# First stage will be RunSamples, which will produce parameter point files in hdf5 format.
+# Each lasdi command will save a restart file, which will be read on the next lasdi command.
+# So all stages are run by the same command, directed differently by the restart file.
+lasdi burgers1d.offline.yml
+
+# Run/save FOM solution with offline FOM solver.
+burgers1d burgers1d.offline.yml
+
+# Collect FOM solution.
+lasdi burgers1d.offline.yml
+
+# Train latent dynamics model.
+lasdi burgers1d.offline.yml
+
+for k in {0..8}
+do
+    # Pick a new sample from greedy sampling
+    lasdi burgers1d.offline.yml
+
+    # A cycle of RunSamples/offline FOM/CollectSamples
+    lasdi burgers1d.offline.yml
+    burgers1d burgers1d.offline.yml
+    lasdi burgers1d.offline.yml
+
+    # Train latent dynamics model.
+    lasdi burgers1d.offline.yml
+done

--- a/examples/burgers1d.offline.bash
+++ b/examples/burgers1d.offline.bash
@@ -1,29 +1,48 @@
 #!/usr/bin/bash
 
-# First stage will be RunSamples, which will produce parameter point files in hdf5 format.
+check_result () {
+  # $1: Result output of the previous command ($?)
+  # $2: Name of the previous command
+  if [ $1 -eq 0 ]; then
+      echo "$2 succeeded"
+  else
+      echo "$2 failed"
+      exit -1
+  fi
+}
+
+# First stage will be PickSample, which will produce parameter point files in hdf5 format.
 # Each lasdi command will save a restart file, which will be read on the next lasdi command.
 # So all stages are run by the same command, directed differently by the restart file.
 lasdi burgers1d.offline.yml
+check_result $? initial-picksample
 
 # Run/save FOM solution with offline FOM solver.
 burgers1d burgers1d.offline.yml
+check_result $? initial-runsample
 
 # Collect FOM solution.
 lasdi burgers1d.offline.yml
+check_result $? initial-collect
 
 # Train latent dynamics model.
 lasdi burgers1d.offline.yml
+check_result $? initial-train
 
 for k in {0..8}
 do
     # Pick a new sample from greedy sampling
     lasdi burgers1d.offline.yml
+    check_result $? pick-sample
 
-    # A cycle of RunSamples/offline FOM/CollectSamples
-    lasdi burgers1d.offline.yml
+    # A cycle of offline FOM/CollectSamples
     burgers1d burgers1d.offline.yml
+    check_result $? run-sample
+
     lasdi burgers1d.offline.yml
+    check_result $? collect-sample
 
     # Train latent dynamics model.
     lasdi burgers1d.offline.yml
+    check_result $? train
 done

--- a/examples/burgers1d.offline.yml
+++ b/examples/burgers1d.offline.yml
@@ -1,0 +1,61 @@
+lasdi:
+  type: gplasdi
+  gplasdi:
+    # device: mps
+    n_samples: 20
+    lr: 0.001
+    max_iter: 2000
+    n_iter: 200
+    max_greedy_iter: 2000
+    ld_weight: 0.1
+    coef_weight: 1.e-6
+    path_checkpoint: checkpoint
+    path_results: results
+
+workflow:
+  use_restart: true
+  restart_file: restarts/burgers1d.restart.npy
+  offline_greedy_sampling:
+    train_param_file: sampling/new_train.burgers1d.h5
+    test_param_file: sampling/new_test.burgers1d.h5
+    train_sol_file: sampling/new_Xtrain.burgers1d.h5
+    test_sol_file: sampling/new_Xtest.burgers1d.h5
+
+parameter_space:
+  parameters:
+    - name: a
+      min: 0.7
+      max: 0.9
+      test_space_type: uniform
+      sample_size: 11
+      log_scale: false
+    - name: w
+      min: 0.9
+      max: 1.1
+      test_space_type: uniform
+      sample_size: 11
+      log_scale: false
+  test_space:
+    type: grid
+
+latent_space:
+  type: ae
+  ae:
+    hidden_units: [100]
+    latent_dimension: 5
+
+latent_dynamics:
+  type: sindy
+  sindy:
+    fd_type: sbp12
+    coef_norm_order: fro
+
+physics:
+  type: burgers1d
+  burgers1d:
+    offline_driver: true
+    number_of_timesteps: 1001
+    simulation_time: 1.
+    grid_size: [1001]
+    xmin: -3.
+    xmax: 3.

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -12,6 +12,10 @@ lasdi:
     path_checkpoint: checkpoint
     path_results: results
 
+workflow:
+  use_restart: true
+  restart_file: restarts/burgers1d.restart.npy
+
 parameter_space:
   parameters:
     - name: a

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -7,14 +7,19 @@ lasdi:
     n_iter: 28000
     n_greedy: 2000
     max_greedy_iter: 28000
-    sindy_weight: 0.1
+    ld_weight: 0.1
     coef_weight: 1.e-6
     path_checkpoint: checkpoint
     path_results: results
 
 workflow:
-  use_restart: true
+  use_restart: false
   restart_file: restarts/burgers1d.restart.npy
+  offline_greedy_sampling:
+    train_param_file: sampling/new_train.burgers1d.h5
+    test_param_file: sampling/new_test.burgers1d.h5
+    train_sol_file: sampling/new_Xtrain.burgers1d.h5
+    test_sol_file: sampling/new_Xtest.burgers1d.h5
 
 parameter_space:
   parameters:
@@ -56,6 +61,7 @@ initial_train:
 physics:
   type: burgers1d
   burgers1d:
+    offline_driver: false
     number_of_timesteps: 1001
     simulation_time: 1.
     grid_size: [1001]

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -4,8 +4,8 @@ lasdi:
     # device: mps
     n_samples: 20
     lr: 0.001
-    n_iter: 28000
-    n_greedy: 2000
+    max_iter: 28000
+    n_iter: 2000
     max_greedy_iter: 28000
     ld_weight: 0.1
     coef_weight: 1.e-6
@@ -52,11 +52,6 @@ latent_dynamics:
   sindy:
     fd_type: sbp12
     coef_norm_order: fro
-
-# TODO(kevin): temporary placeholder
-initial_train:
-  train_data: data/data_train.npy
-  test_data: data/data_test.npy
 
 physics:
   type: burgers1d

--- a/examples/template_training.ipynb
+++ b/examples/template_training.ipynb
@@ -1,0 +1,510 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d31d3171",
+   "metadata": {},
+   "source": [
+    "# Template for autoencoder prototyping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d67dad03-9d76-4891-82ff-7e19d1369a24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import numpy as np\n",
+    "from matplotlib.colors import LinearSegmentedColormap\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.animation as animation\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Name for the case\n",
+    "name = 'template'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fceceb92",
+   "metadata": {},
+   "source": [
+    "## Hyper-parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b05f7c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = 1.0e-5\n",
+    "ae_weight = 1e0\n",
+    "sindy_weight = 1.e-6\n",
+    "coef_weight= 1.e-9\n",
+    "lr = 1e-5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55bc1410",
+   "metadata": {},
+   "source": [
+    "## Training data\n",
+    "\n",
+    "- Consider we only have one time-series simulation.\n",
+    "- suppose we have grid of size (20x30) points.\n",
+    "- solution is a 2-dimensional vector (on each grid point)\n",
+    "- A simulation of 50 time steps.\n",
+    "- the first index of snapshot array should be timestep.\n",
+    "- we consider dof as solution dimension, and number of particles as grid size.\n",
+    "\n",
+    "Can load other data files for your custom autoencoder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca3062c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ntrain = 1\n",
+    "sol_dim = 2\n",
+    "grid_dim = [20,30]\n",
+    "nt = 50\n",
+    "\n",
+    "# number of cases x number of time step x solution dimension x grid size\n",
+    "snapshots = np.random.rand(ntrain, nt, sol_dim, grid_dim[0], grid_dim[1])\n",
+    "X_train = torch.Tensor(snapshots)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b6241c5",
+   "metadata": {},
+   "source": [
+    "## Setting up a physics wrapper.\n",
+    "\n",
+    "You can choose from `lasdi.physics` module, or create a custom physics model. Following snippet is an example with some necessary specifications."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a0349ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.physics import Physics\n",
+    "\n",
+    "class CustomPhysicsModel(Physics):\n",
+    "    def __init__(self):\n",
+    "        self.dim = 2\n",
+    "        self.nt = nt\n",
+    "        self.dt = dt\n",
+    "        self.qdim = sol_dim\n",
+    "        self.grid_size = grid_dim\n",
+    "        self.qgrid_size = [sol_dim] + grid_dim\n",
+    "\n",
+    "        ''' Set up a grid as you see fit. '''\n",
+    "        self.x_grid = np.zeros([self.dim] + self.grid_size)\n",
+    "        xg = np.linspace(0., 1., grid_dim[1])\n",
+    "        yg = np.linspace(0., 1., grid_dim[0])\n",
+    "        self.x_grid[0], self.x_grid[1] = np.meshgrid(xg, yg)\n",
+    "        return\n",
+    "    \n",
+    "    ''' See lasdi.physics.Physics class for necessary subroutines '''\n",
+    "\n",
+    "physics = CustomPhysicsModel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9996b792",
+   "metadata": {},
+   "source": [
+    "## Setting up autoencoder\n",
+    "\n",
+    "You can choose from `lasdi.latent_space` module, or create a custom autoencoder. The snippet below uses a built-in `Autoencoder` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c53127b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.latent_space import Autoencoder\n",
+    "\n",
+    "n_train = 1\n",
+    "hidden_units = [3000, 300, 300, 100, 100, 30]\n",
+    "# latent space dimension\n",
+    "n_z = 5\n",
+    "print(physics.grid_size, hidden_units, n_z)\n",
+    "\n",
+    "# I think these options are straightforward.\n",
+    "ae_cfg = {'hidden_units': hidden_units, 'latent_dimension': n_z, 'activation': 'softplus'}\n",
+    "\n",
+    "ae = Autoencoder(physics, ae_cfg)\n",
+    "best_loss = np.Inf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0ea7a53",
+   "metadata": {},
+   "source": [
+    "## Setting up latent dynamics\n",
+    "\n",
+    "Similarly, we either choose a latent dynamics model from `lasdi.latent_dynamics` module or create a custom model. Here we use `SINDy` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad4ae3ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.latent_dynamics.sindy import SINDy\n",
+    "\n",
+    "sindy_options = {'sindy': {'fd_type': 'sbp12'}} # finite-difference operator for computing time derivative of latent trajectory.\n",
+    "ld = SINDy(ae.n_z, physics.nt, sindy_options)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5d98899",
+   "metadata": {},
+   "source": [
+    "## Training: (1) Running a custom optimization process"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36bacfa9",
+   "metadata": {},
+   "source": [
+    "Set up optimizer and loss term"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31de72b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer = torch.optim.Adam(ae.parameters(), lr = lr)\n",
+    "MSE = torch.nn.MSELoss()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55cfb184",
+   "metadata": {},
+   "source": [
+    "Set up device: `'cuda'`, `'mps'` (apple) or `'cpu'`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35cd5db2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = 'cpu'\n",
+    "d_ae = ae.to(device)\n",
+    "d_Xtrain = X_train.to(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65bc550a",
+   "metadata": {},
+   "source": [
+    "This is a part of GPLaSDI training procedure, where the training is executed without on-the-fly sampling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff367763",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_iter = 10\n",
+    "save_interval = 1\n",
+    "hist_file = '%s.loss_history.txt' % name\n",
+    "\n",
+    "loss_hist = np.zeros([n_iter, 4])\n",
+    "grad_hist = np.zeros([n_iter, 4])\n",
+    "for iter in range(n_iter):\n",
+    "    optimizer.zero_grad()\n",
+    "    d_ae = ae.to(device)\n",
+    "    d_Z = d_ae.encoder(d_Xtrain)\n",
+    "    d_Xpred = d_ae.decoder(d_Z)\n",
+    "    Z = d_Z.cpu()\n",
+    "\n",
+    "    loss_ae = MSE(d_Xtrain, d_Xpred)\n",
+    "    coefs, loss_sindy, loss_coef = ld.calibrate(Z, physics.dt, compute_loss=True, numpy=True)\n",
+    "\n",
+    "    max_coef = np.abs(np.array(coefs)).max()\n",
+    "    loss = ae_weight * loss_ae + sindy_weight * loss_sindy / n_train + coef_weight * loss_coef / n_train\n",
+    "\n",
+    "    loss_hist[iter] = [loss.item(), loss_ae.item(), loss_sindy.item(), loss_coef.item()]\n",
+    "\n",
+    "    loss.backward()\n",
+    "\n",
+    "    optimizer.step()\n",
+    "\n",
+    "    if ((loss.item() < best_loss) and (iter % save_interval == 0)):\n",
+    "        torch.save(d_ae.cpu().state_dict(), './%s_checkpoint.pt' % name)\n",
+    "        best_loss = loss.item()\n",
+    "\n",
+    "    # print(\"Iter: %05d/%d, Loss: %.5e\" % (iter + 1, n_iter, loss.item()))\n",
+    "    print(\"Iter: %05d/%d, Loss: %.5e, Loss AE: %.5e, Loss SI: %.5e, Loss COEF: %.5e, max|c|: %.5e\"\n",
+    "            % (iter + 1, n_iter, loss.item(), loss_ae.item(), loss_sindy.item(), loss_coef.item(), max_coef))\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "015d02f5",
+   "metadata": {},
+   "source": [
+    "Save the history and the trained parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb293bb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.savetxt('%s.loss_history.txt' % name, loss_hist)\n",
+    "\n",
+    "if (loss.item() < best_loss):\n",
+    "    torch.save(d_ae.cpu().state_dict(), './%s_checkpoint.pt' % name)\n",
+    "    best_loss = loss.item()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97f719d3",
+   "metadata": {},
+   "source": [
+    "Load a checkpoint and re-evaluate the losses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00f7da25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state_dict = torch.load('%s_checkpoint.pt' % name)\n",
+    "ae.load_state_dict(state_dict)\n",
+    "ae.eval()\n",
+    "d_ae = ae.to(device)\n",
+    "d_Z = d_ae.encoder(d_Xtrain)\n",
+    "d_Xpred = d_ae.decoder(d_Z)\n",
+    "Z = d_Z.cpu()\n",
+    "print(Z.shape)\n",
+    "\n",
+    "loss_ae = MSE(d_Xtrain, d_Xpred)\n",
+    "coefs, loss_sindy, loss_coef = ld.calibrate(Z, physics.dt, compute_loss=True, numpy=True)\n",
+    "\n",
+    "max_coef = np.abs(np.array(coefs)).max()\n",
+    "loss = loss_ae + sindy_weight * loss_sindy / n_train + coef_weight * loss_coef / n_train\n",
+    "print(loss.item())\n",
+    "print(loss_ae.item())\n",
+    "print((sindy_weight * loss_sindy / n_train).item())\n",
+    "print((coef_weight * loss_coef / n_train).item())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6516cfa7",
+   "metadata": {},
+   "source": [
+    "Visualize the loss history"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d62570fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss_hist = np.loadtxt('%s.loss_history.txt' % name)\n",
+    "\n",
+    "plt.figure(1)\n",
+    "plt.loglog(loss_hist[:, 0])\n",
+    "plt.xlabel('iteration')\n",
+    "plt.ylabel('loss')\n",
+    "\n",
+    "plt.rcParams.update({'font.size': 15})\n",
+    "plt.figure(2, figsize=(8, 6))\n",
+    "plt.loglog(loss_hist[:, 1:])\n",
+    "plt.xlabel('iteration')\n",
+    "plt.ylabel('loss')\n",
+    "plt.legend([\"ae\", \"sindy\", \"coef\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82af6aa5",
+   "metadata": {},
+   "source": [
+    "Obtain the predicted solution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4692510d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tgrid = np.linspace(0, (nt-1)*dt, nt)\n",
+    "\n",
+    "d_Z = d_ae.encoder(d_Xtrain)\n",
+    "Z = d_Z.cpu().detach().numpy()\n",
+    "\n",
+    "Zpred = np.zeros([n_train, physics.nt, ae.n_z])\n",
+    "for case_idx in range(len(coefs)):\n",
+    "    Zpred[case_idx] = ld.simulate(coefs[case_idx], Z[case_idx, 0], tgrid)\n",
+    "\n",
+    "d_Zpred = torch.Tensor(Zpred).to(device)\n",
+    "X_pred = d_ae.decoder(d_Zpred).cpu().detach().numpy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38cafdda",
+   "metadata": {},
+   "source": [
+    "Plot the latent variable evolution and compare the prediction with the truth"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f178a53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colors = ['r','g','b','c','m']\n",
+    "\n",
+    "for case_idx in range(len(coefs)):\n",
+    "    plt.figure(1+case_idx, figsize=(8,6))\n",
+    "    for k, color in enumerate(colors):\n",
+    "        plt.plot(Zpred[case_idx][:, k],'-'+color)\n",
+    "        plt.plot(Z[case_idx][:, k],'--'+color)\n",
+    "    plt.ylabel('$Z$')\n",
+    "    plt.xlabel('$t$ ($\\\\times\\Delta t$)')\n",
+    "    plt.legend(['pred','truth'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfb4c0bf",
+   "metadata": {},
+   "source": [
+    "Visualization of full-order model solution.\n",
+    "Feel free to change as you see fit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da08d933",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "case_idx = 0\n",
+    "time_idx = 14\n",
+    "var_idx = 0\n",
+    "\n",
+    "truth = snapshots[case_idx, time_idx, var_idx]\n",
+    "pred = X_pred[case_idx, time_idx, var_idx]\n",
+    "\n",
+    "plt.figure(1)\n",
+    "plt.contourf(physics.x_grid[0], physics.x_grid[1], truth, 200)\n",
+    "\n",
+    "plt.figure(2)\n",
+    "plt.contourf(physics.x_grid[0], physics.x_grid[1], pred, 200)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71653612",
+   "metadata": {},
+   "source": [
+    "## Training: (2) Using built-in GPLaSDI trainer\n",
+    "\n",
+    "**Work in progress**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ad84e16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.gplasdi import BayesianGLaSDI\n",
+    "\n",
+    "trainer_options = {'n_samples': 20,         # number of samples when choosing a new parameter point. Not used in this case\n",
+    "                   'lr': lr,                # learning rate\n",
+    "                   'n_iter': 10000,         # number of iteration in training\n",
+    "                   'max_greedy_iter': 0,    # maximum iteration to perform greedy sampling. Not used in this case\n",
+    "                   'n_greedy': -1,          # frequency of greedy sampling. Not used in this case\n",
+    "                   'sindy_weight': sindy_weight, # weight for latent dynamics loss\n",
+    "                   'coef_weight': coef_weight,   # weight for latent dynamics coefficient regularization\n",
+    "                   'device': 'cpu',              # device to perform training (cpu, cuda, mps)\n",
+    "                   'path_checkpoint': 'checkpoints', # directory to save training checkpoint files\n",
+    "                   'path_results': 'results',        # directory to save training results\n",
+    "                   }\n",
+    "\n",
+    "trainer = BayesianGLaSDI(physics, ae, ld, trainer_options)\n",
+    "trainer.X_train = X_train\n",
+    "\n",
+    "trainer.train()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv_gpu",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
   "scipy>=1.10",
   "pyyaml>=6.0",
   "matplotlib>=3.8.0",
-  "argparse>=1.1"
+  "argparse>=1.1",
+  "h5py"
 ]
 
 [project.urls]
@@ -34,3 +35,4 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 lasdi = "lasdi.workflow:main [config_file]"
+burgers1d = "lasdi.physics.burgers1d:main [config_file]"

--- a/src/lasdi/enums.py
+++ b/src/lasdi/enums.py
@@ -1,8 +1,8 @@
 from enum import Enum
 
 class NextStep(Enum):
-    Initial = 1
-    Train = 2
+    Train = 1
+    PickSample = 2
     RunSample = 3
     CollectSample = 4
 

--- a/src/lasdi/gplasdi.py
+++ b/src/lasdi/gplasdi.py
@@ -92,7 +92,7 @@ class BayesianGLaSDI:
     X_train = torch.Tensor([])
     X_test = torch.Tensor([])
 
-    def __init__(self, physics, autoencoder, latent_dynamics, config):
+    def __init__(self, physics, autoencoder, latent_dynamics, param_space, config):
 
         '''
 
@@ -106,7 +106,7 @@ class BayesianGLaSDI:
         self.autoencoder = autoencoder
         self.latent_dynamics = latent_dynamics
         self.physics = physics
-        self.param_space = physics.param_space
+        self.param_space = param_space
         self.timer = Timer()
 
         self.n_samples = config['n_samples']

--- a/src/lasdi/gplasdi.py
+++ b/src/lasdi/gplasdi.py
@@ -257,7 +257,7 @@ class BayesianGLaSDI:
 
         m_index = get_fom_max_std(ae, Zis)
 
-        new_sample = ps.test_space[m_index, :]
+        new_sample = ps.test_space[m_index, :].reshape(1, -1)
         print('New param: ' + str(np.round(new_sample, 4)) + '\n')
 
         self.timer.end("new_sample")

--- a/src/lasdi/latent_dynamics/__init__.py
+++ b/src/lasdi/latent_dynamics/__init__.py
@@ -57,3 +57,10 @@ class LatentDynamics:
         param_dict = {'dim': self.dim, 'ncoefs': self.ncoefs}
         return param_dict
     
+    # SINDy does not need to load parameters.
+    # Other latent dynamics might need to.
+    def load(self, dict_):
+        assert(self.dim == dict_['dim'])
+        assert(self.ncoefs == dict_['ncoefs'])
+        return
+    

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -15,7 +15,6 @@ def initial_condition_latent(param_grid, physics, autoencoder):
     sol_shape = [1, 1] + physics.qgrid_size
 
     for i in range(n_param):
-        # TODO(kevin): generalize parameter class.
         u0 = physics.initial_condition(param_grid[i])
         u0 = u0.reshape(sol_shape)
         u0 = torch.Tensor(u0)

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -175,3 +175,11 @@ class Autoencoder(torch.nn.Module):
         x = x.squeeze(1)  # Remove sequence dimension
         
         return x
+    
+    def export(self):
+        dict_ = {'autoencoder_param': self.cpu().state_dict()}
+        return dict_
+    
+    def load(self, dict_):
+        self.load_state_dict(dict_['autoencoder_param'])
+        return

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -25,8 +25,6 @@ class ParameterSpace:
     n_param = 0
     train_space = None
     test_space = None
-    n_test = 0
-    n_train = 0
     n_init = 0
     test_grid_sizes = []
     test_meshgrid = None
@@ -44,14 +42,18 @@ class ParameterSpace:
 
         self.train_space = self.createInitialTrainSpace(self.param_list)
         self.n_init = self.train_space.shape[0]
-        self.n_train = self.n_init
 
         test_space_type = parser.getInput(['test_space', 'type'], datatype=str)
         if (test_space_type == 'grid'):
             self.test_grid_sizes, self.test_meshgrid, self.test_space = self.createTestGridSpace(self.param_list)
-            self.n_test = self.test_space.shape[0]
 
         return
+    
+    def n_train(self):
+        return self.train_space.shape[0]
+    
+    def n_test(self):
+        return self.test_space.shape[0]
     
     def createInitialTrainSpace(self, param_list):
         paramRanges = []
@@ -129,7 +131,6 @@ class ParameterSpace:
         assert(self.train_space.shape[1] == param.size)
 
         self.train_space = np.vstack((self.train_space, param))
-        self.n_train = self.train_space.shape[0]
         return
     
     def export(self):
@@ -149,7 +150,4 @@ class ParameterSpace:
         assert(self.n_init == dict_['n_init'])
         assert(self.train_space.shape[1] == self.n_param)
         assert(self.test_space.shape[1] == self.n_param)
-
-        self.n_train = self.train_space.shape[0]
-        self.n_test = self.test_space.shape[0]
         return

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -22,6 +22,7 @@ getParam1DSpace = {'list': get_1dspace_from_list,
 class ParameterSpace:
     param_list = []
     param_name = []
+    n_param = 0
     train_space = None
     test_space = None
     n_test = 0
@@ -35,6 +36,7 @@ class ParameterSpace:
         parser = InputParser(config['parameter_space'], name="param_space_input")
 
         self.param_list = parser.getInput(['parameters'], datatype=list)
+        self.n_param = len(self.param_list)
 
         self.param_name = []
         for param in self.param_list:
@@ -131,13 +133,23 @@ class ParameterSpace:
         return
     
     def export(self):
-        dict_ = {'final_param_train': self.train_space,
-                 'param_grid': self.test_space,
+        dict_ = {'train_space': self.train_space,
+                 'test_space': self.test_space,
                  'test_grid_sizes': self.test_grid_sizes,
                  'test_meshgrid': self.test_meshgrid,
                  'n_init': self.n_init}
         return dict_
     
-    def loadTrainSpace(self):
-        raise RuntimeError("ParameterSpace.loadTrainSpace is not implemented yet!")
+    def load(self, dict_):
+        self.train_space = dict_['train_space']
+        self.test_space = dict_['test_space']
+        self.test_grid_sizes = dict_['test_grid_sizes']
+        self.test_meshgrid = dict_['test_meshgrid']
+
+        assert(self.n_init == dict_['n_init'])
+        assert(self.train_space.shape[1] == self.n_param)
+        assert(self.test_space.shape[1] == self.n_param)
+
+        self.n_train = self.train_space.shape[0]
+        self.n_test = self.test_space.shape[0]
         return

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -90,7 +90,9 @@ class OfflineFOM(Physics):
         self.qdim = parser.getInput(['solution_dimension'], datatype=int)
 
         self.grid_size = parser.getInput(['grid_size'], datatype=list)
-        self.qgrid_size = [self.qdim] + self.grid_size
+        self.qgrid_size = self.grid_size
+        if (self.qdim > 1):
+            self.qgrid_size = [self.qdim] + self.qgrid_size
         assert(self.dim == len(self.grid_size))
 
         #TODO(kevin): a general file loading for spatial grid
@@ -107,3 +109,8 @@ class OfflineFOM(Physics):
     def generate_solutions(self, params):
         raise RuntimeError("OfflineFOM does not support generate_solutions!!")
         return
+
+    def export(self):
+        dict_ = {'t_grid' : self.t_grid, 'x_grid' : self.x_grid, 'dt' : self.dt}
+        return dict_
+

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -63,6 +63,7 @@ class Physics:
         X_train = None
         for k, param in enumerate(params):
             new_X = self.solve(param)
+            assert(new_X.size(0) == 1) # should contain one parameter case.
             if (X_train is None):
                 X_train = new_X
             else:
@@ -75,3 +76,34 @@ class Physics:
     def residual(self, Xhist):
         raise RuntimeError("Abstract method Physics.residual!")
         return res, res_norm
+    
+class OfflineFOM(Physics):
+    def __init__(self, param_space, cfg):
+        super().__init__(param_space, cfg)
+        self.offline = True
+
+        assert('offline_fom' in cfg)
+        from ..inputs import InputParser
+        parser = InputParser(cfg['offline_fom'], name="offline_fom_input")
+
+        self.dim = parser.getInput(['space_dimension'], datatype=int)
+        self.qdim = parser.getInput(['solution_dimension'], datatype=int)
+
+        self.grid_size = parser.getInput(['grid_size'], datatype=list)
+        self.qgrid_size = [self.qdim] + self.grid_size
+        assert(self.dim == len(self.grid_size))
+
+        #TODO(kevin): a general file loading for spatial grid
+        #             There can be unstructured grids as well.
+        self.x_grid = None
+
+        # Assume uniform time stepping for now.
+        self.nt = parser.getInput(['number_of_timesteps'], datatype=int)
+        self.dt = parser.getInput(['timestep_size'], datatype=float)
+        self.t_grid = np.linspace(0.0, (self.nt-1) * self.dt, self.nt)
+
+        return
+    
+    def generate_solutions(self, params):
+        raise RuntimeError("OfflineFOM does not support generate_solutions!!")
+        return

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -57,6 +57,7 @@ class Physics:
         params.shape[1] must match the required size of
         parameters for the specific physics.
         '''
+        assert(params.ndim == 2)
         n_param = len(params)
         print("Generating %d samples" % n_param)
 

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -31,11 +31,11 @@ class Physics:
     # Set at the initialization.
     offline = False
 
-    # ParameterSpace object to parse parameters.
-    param_space = None
+    # list of parameter names to parse parameters.
+    param_name = None
 
-    def __init__(self, param_space, cfg):
-        self.param_space = param_space
+    def __init__(self, cfg, param_name=None):
+        self.param_name = param_name
         return
     
     def initial_condition(self, param):
@@ -78,8 +78,8 @@ class Physics:
         return res, res_norm
     
 class OfflineFOM(Physics):
-    def __init__(self, param_space, cfg):
-        super().__init__(param_space, cfg)
+    def __init__(self, cfg, param_name=None):
+        super().__init__(cfg, param_name)
         self.offline = True
 
         assert('offline_fom' in cfg)

--- a/src/lasdi/physics/burgers1d.py
+++ b/src/lasdi/physics/burgers1d.py
@@ -7,8 +7,11 @@ from . import Physics
 from ..fd import FDdict
 
 class Burgers1D(Physics):
-    def __init__(self, param_space, cfg):
-        super().__init__(param_space, cfg)
+    a_idx = None # parameter index for a
+    w_idx = None # parameter index for w
+
+    def __init__(self, cfg, param_name=None):
+        super().__init__(cfg, param_name)
 
         self.qdim = 1
         self.dim = 1
@@ -36,12 +39,20 @@ class Burgers1D(Physics):
 
         self.maxk = parser.getInput(['maxk'], fallback=10)
         self.convergence_threshold = parser.getInput(['convergence_threshold'], fallback=1.e-8)
+
+        if (self.param_name is not None):
+            if 'a' in self.param_name:
+                self.a_idx = self.param_name.index('a')
+            if 'w' in self.param_name:
+                self.w_idx = self.param_name.index('w')
         return
     
     def initial_condition(self, param):
-        param = self.param_space.getParameter(param)
-        a = param['a'] if 'a' in param else 1.0
-        w = param['w'] if 'w' in param else 1.0
+        a, w = 1.0, 1.0
+        if 'a' in self.param_name:
+            a = param[self.a_idx]
+        if 'w' in self.param_name:
+            w = param[self.w_idx]
 
         return a * np.exp(- self.x_grid ** 2 / 2 / w / w)
     
@@ -153,7 +164,7 @@ def main():
     # initialize parameter space and physics class
     from ..param import ParameterSpace
     param_space = ParameterSpace(config)
-    physics = Burgers1D(param_space, config['physics'])
+    physics = Burgers1D(config['physics'], param_space.param_name)
 
     # read training parameter points
     train_param_file = cfg_parser.getInput(['workflow', 'offline_greedy_sampling', 'train_param_file'], datatype=str)

--- a/src/lasdi/timing.py
+++ b/src/lasdi/timing.py
@@ -40,8 +40,22 @@ class Timer:
         return
     
     def export(self):
+        for start in self.starts:
+            if (start is not None):
+                raise RuntimeError('Timer.export: cannot export while Timer is still ticking!')
+
         param_dict = {}
         param_dict["names"] = self.names
         param_dict["calls"] = self.calls
         param_dict["times"] = self.times
         return param_dict
+    
+    def load(self, dict_):
+        self.names = dict_['names']
+        self.calls = dict_['calls']
+        self.times = dict_['times']
+
+        assert(len(self.names) == len(self.calls))
+        assert(len(self.names) == len(self.times))
+        self.starts = [None] * len(self.names)
+        return

--- a/src/lasdi/workflow.py
+++ b/src/lasdi/workflow.py
@@ -9,6 +9,7 @@ from .latent_space import Autoencoder
 from .latent_dynamics.sindy import SINDy
 from .physics.burgers1d import Burgers1D
 from .param import ParameterSpace
+from .inputs import InputParser
 
 trainer_dict = {'gplasdi': BayesianGLaSDI}
 
@@ -29,63 +30,102 @@ def main():
 
     with open(args.config_file, 'r') as f:
         config = yaml.safe_load(f)
+        cfg_parser = InputParser(config, name='main')
 
-    trainer = initialize_trainer(config)
+    use_restart = cfg_parser.getInput(['workflow', 'use_restart'], fallback=False)
+    if (use_restart):
+        restart_filename = cfg_parser.getInput(['workflow', 'restart_file'], datatype=str)
+        from os.path import dirname
+        from pathlib import Path
+        Path(dirname(restart_filename)).mkdir(parents=True, exist_ok=True)
 
-    if ('restart_file' in config):
-        restart_file = np.load(config['restart_file'], allow_pickle=True).item()
-        next_step = restart_file['next_step']
+    import os
+    if (use_restart and (os.path.isfile(restart_filename))):
+        # TODO(kevin): in long term, we should switch to hdf5 format.
+        restart_file = np.load(restart_filename, allow_pickle=True).item()
+        current_step = restart_file['next_step']
         result = restart_file['result']
     else:
-        next_step = NextStep.Initial
+        restart_file = None
+        current_step = NextStep.Initial
         result = Result.Unexecuted
+    
+    trainer, param_space, physics, latent_space, latent_dynamics = initialize_trainer(config, restart_file)
+
+    result, next_step = step(trainer, current_step, config, use_restart)
 
     if (result is Result.Fail):
         raise RuntimeError('Previous step has failed. Stopping the workflow.')
+    elif (result is Result.Success):
+        print("Previous step succeeded. Preparing for the next step.")
+        result = Result.Unexecuted
     elif (result is Result.Complete):
         print("Workflow is finished.")
-        return result
 
-    result = step(trainer, next_step, config)
+    # save restart (or final) file.
+    import time
+    date = time.localtime()
+    date_str = "{month:02d}_{day:02d}_{year:04d}_{hour:02d}_{minute:02d}"
+    date_str = date_str.format(month = date.tm_mon, day = date.tm_mday, year = date.tm_year, hour = date.tm_hour + 3, minute = date.tm_min)
+    if (use_restart):
+        # rename old restart file if exists.
+        if (os.path.isfile(restart_filename)):
+            old_timestamp = restart_file['timestamp']
+            os.rename(restart_filename, restart_filename + '.' + old_timestamp)
+        save_file = restart_filename
+    else:
+        save_file = 'lasdi_' + date_str + '.npy'
+    
+    save_dict = {'parameters': param_space.export(),
+                 'physics': physics.export(),
+                 'latent_space': latent_space.export(),
+                 'latent_dynamics': latent_dynamics.export(),
+                 'trainer': trainer.export(),
+                 'timestamp': date_str,
+                 'next_step': next_step,
+                 'result': result, # TODO(kevin): do we need to save result?
+                 }
+    
+    np.save(save_file, save_dict)
 
     return result
 
-def step(trainer, next_step, config):
-    # TODO(kevin): implement save/load workflow.
-    continue_workflow = True
+def step(trainer, next_step, config, use_restart=False):
 
     if (next_step is NextStep.Initial):
 
         result, next_step = initial_step(trainer, config)
-        if (continue_workflow):
-            result = step(trainer, next_step, config)
 
     elif (next_step is NextStep.Train):
 
         result, next_step = trainer.train()
-        if (result is Result.Complete):
-            return result
-        else:
-            assert(next_step is NextStep.RunSample)
-            result = step(trainer, next_step, config)
 
     elif (next_step is NextStep.RunSample):
 
         trainer.sample_fom()
         # TODO(kevin): currently no offline fom simulation. skip CollectSample.
         result, next_step = Result.Success, NextStep.Train
-        result = step(trainer, next_step, config)
+        # result = step(trainer, next_step, config)
 
     elif (next_step is NextStep.CollectSample):
         import warnings
         warnings.warn("Collecting sample from offline FOM simulation is not implemented yet")
+        result, next_step = Result.Success, NextStep.RunSample
 
     else:
         raise RuntimeError("Unknown next step!")
+    
+    # if fail or complete, break the loop regardless of use_restart.
+    if ((result is Result.Fail) or (result is Result.Complete)):
+        return result, next_step
+    
+    # continue the workflow if not using restart.
+    if (not use_restart):
+        result, next_step = step(trainer, next_step, config)
 
-    return result
+    return result, next_step
 
-def initialize_trainer(config):
+def initialize_trainer(config, restart_file=None):
     '''
     Initialize a LaSDI class with a latent space model according to config file.
     Currently only 'gplasdi' is available.
@@ -93,23 +133,31 @@ def initialize_trainer(config):
 
     # TODO(kevin): load parameter train space from a restart file.
     param_space = ParameterSpace(config)
+    if (restart_file is not None):
+        param_space.load(restart_file['parameters'])
 
     physics = initialize_physics(param_space, config)
     latent_space = initialize_latent_space(physics, config)
+    if (restart_file is not None):
+        latent_space.load(restart_file['latent_space'])
 
     # do we need a separate routine for latent dynamics initialization?
     ld_type = config['latent_dynamics']['type']
     assert(ld_type in config['latent_dynamics'])
     assert(ld_type in ld_dict)
     latent_dynamics = ld_dict[ld_type](latent_space.n_z, physics.nt, config['latent_dynamics'])
+    if (restart_file is not None):
+        latent_dynamics.load(restart_file['latent_dynamics'])
 
     trainer_type = config['lasdi']['type']
     assert(trainer_type in config['lasdi'])
     assert(trainer_type in trainer_dict)
 
     trainer = trainer_dict[trainer_type](physics, latent_space, latent_dynamics, config['lasdi'][trainer_type])
+    if (restart_file is not None):
+        trainer.load(restart_file['trainer'])
 
-    return trainer
+    return trainer, param_space, physics, latent_space, latent_dynamics
 
 def initialize_latent_space(physics, config):
     '''

--- a/src/lasdi/workflow.py
+++ b/src/lasdi/workflow.py
@@ -149,7 +149,7 @@ def initialize_trainer(config, restart_file=None):
     if (restart_file is not None):
         param_space.load(restart_file['parameters'])
 
-    physics = initialize_physics(param_space, config)
+    physics = initialize_physics(config, param_space.param_name)
     latent_space = initialize_latent_space(physics, config)
     if (restart_file is not None):
         latent_space.load(restart_file['latent_space'])
@@ -166,7 +166,7 @@ def initialize_trainer(config, restart_file=None):
     assert(trainer_type in config['lasdi'])
     assert(trainer_type in trainer_dict)
 
-    trainer = trainer_dict[trainer_type](physics, latent_space, latent_dynamics, config['lasdi'][trainer_type])
+    trainer = trainer_dict[trainer_type](physics, latent_space, latent_dynamics, param_space, config['lasdi'][trainer_type])
     if (restart_file is not None):
         trainer.load(restart_file['trainer'])
 
@@ -188,7 +188,7 @@ def initialize_latent_space(physics, config):
 
     return latent_space
 
-def initialize_physics(param_space, config):
+def initialize_physics(config, param_name):
     '''
     Initialize a physics FOM model according to config file.
     Currently only 'burgers1d' is available.
@@ -196,7 +196,7 @@ def initialize_physics(param_space, config):
 
     physics_cfg = config['physics']
     physics_type = physics_cfg['type']
-    physics = physics_dict[physics_type](param_space, physics_cfg)
+    physics = physics_dict[physics_type](physics_cfg, param_name)
 
     return physics
 


### PR DESCRIPTION
# Restart capability
The workflow now supports restart capability, saving/loading necessary data to/from a restart file.
- Following classes support `export` and `load` function, which saves/loads from a dictionary:
  - `Autoencoder`
  - `ParameterSpace`
  - `LatentDynamics`, `SINDy`
  - `Physics`, `Burgers1D`
  - `BayesianGLaSDI`
  - `Timer`
- `lasdi.workflow.main` function saves/loads all these classes into/from a restart file.

# Interface to offline FOM simulations
For greedy sampling, new FOM solutions are added to the training data. For offline FOM simulations, the python training needs to be paused, so that FOM simulation runs for new parameter points and saves the solution ready to read from python framework. This is now supported by two workflow stages `NextStep.RunSamples` and `NextStep.CollectSamples`.
- `lasdi.workflow.run_samples`
  - if FOM is built in python framework, it runs FOM simulation without pausing python framework
  - If FOM is offline solver, then it rather saves the new parameter points in a hdf5 file which FOM solver may read for simulation.
  - It saves parameter points for training data and test data separately.
  - The parameter point file names are specified in yaml input file as:
    - `['workflow']['offline_greedy_sampling']['train_param_file']`
    - `['workflow']['offline_greedy_sampling']['test_param_file']`
- `lasdi.workflow.collect_samples`
  - if FOM is built-in python solver, this routine is not needed.
  - If FOM is offline solver, FOM will produce the solution (on an outside script) according to the parameter points saved from `run_samples`. `collect_samples` then reads the solution and appends training/test data.
    - The FOM solution file names are specified in yaml input file as:
    - `['workflow']['offline_greedy_sampling']['train_sol_file']`
    - `['workflow']['offline_greedy_sampling']['test_sol_file']`
- For this interface, `h5py` package is used to use hdf5 format, which can be well accessed from most of programming languages (supposedly).

# Offline FOM wrapper and offline driver for Burgers 1D equation
- `lasdi.physics.OfflineFOM` provides a wrapper for offline FOM simulation. It does not solve/run any simulation, rather only specifies spatial/time grid size and solution dimension.
- A separate executable `burgers1d` provides a offline, command-line driver for Burgers 1D equation. It reads input options from a yaml file. In essence, it provides the offline FOM part that connects to the interface described above.

# Factorizing training and greedy sampling stages
- Previously, `BayesianGLaSDI.train` performs both training and greedy sampling. This is now separated into `train` and `get_new_sample_point`.
- `lasdi.workflow.pick_samples` runs `BayesianGLaSDI.get_new_sample_point` and append the parameter training space.
- These two stages are run as separate stages `NextStep.Train` and `NextStep.PickSamples`.

# Prerequisites addition
`h5py` package is required for saving/loading parameters and FOM solutions.

# Full workflow demonstration of Burgers 1d example
- `examples/burgers1d.ipynb` now also include data generation/training stages, as well as post processing.
- `examples/burgers1d.offline.bash` also demonstrates the entire workflow with offline FOM solver.

# Variable name changes in `BayesianGLaSDI` class
- `n_iter` -> `max_iter`: maximum iteration for the entire workflow
- `n_greedy` -> `n_iter`: number of iteration for one `train` routine. This is also the frequency of greedy sampling.
- `max_greedy_iter` remains the same.

