### PR TITLE
Documentation in latent_space.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ on:
       - main
 
 jobs:
-  docker-image:
-    uses: ./.github/workflows/docker.yml
+  # docker-image:
+  #   uses: ./.github/workflows/docker.yml
   api-doc:
-    needs: [docker-image]
+    # needs: [docker-image]
     uses: ./.github/workflows/sphinx.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+jobs:
+  docker-image:
+    uses: ./.github/workflows/docker.yml
+  api-doc:
+    needs: [docker-image]
+    uses: ./.github/workflows/sphinx.yml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,69 @@
+name: docker-image
+on:
+  workflow_call:
+
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: LLNL/GPLaSDI/lasdi_env
+  DOCKERPATH: docker
+
+jobs:
+  docker-ci:
+    runs-on: ubuntu-latest
+    name: "docker env"
+    env:
+      DOCKERPATH: docker
+    steps:
+      - name: test command
+        run: echo "docker-ci command"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: Ana06/get-changed-files@v2.2.0       
+        id: files
+      - name: DockerPATH configuration
+        run: echo "DOCKERPATH=$DOCKERPATH"
+      - name: DockerPATH - check if files in docker path changed
+        if: contains(steps.files.outputs.all,env.DOCKERPATH) || contains(steps.files.outputs.all,'docker.yml')
+        run: |
+          echo "CI container needs rebuilding..."
+          echo "CI_NEEDS_REBUILD=true" >> $GITHUB_ENV
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: env.CI_NEEDS_REBUILD
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        if: env.CI_NEEDS_REBUILD
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=sha
+          flavor: latest=true
+      - name: Build Container motd
+        if: env.CI_NEEDS_REBUILD
+        run: |
+          echo "#!/bin/bash" > ${{env.DOCKERPATH}}/motd.sh
+          echo "echo --------------------------" >> ${{env.DOCKERPATH}}/motd.sh
+          echo "echo lasdi_env/CI Development Container"  >> ${{env.DOCKERPATH}}/motd.sh
+          echo "echo \"Revision: `echo ${GITHUB_SHA} | cut -c1-8`\"" >> ${{env.DOCKERPATH}}/motd.sh
+          echo "echo --------------------------" >> ${{env.DOCKERPATH}}/motd.sh
+          chmod 755 ${{env.DOCKERPATH}}/motd.sh
+          cat ${{env.DOCKERPATH}}/motd.sh
+      - name: Docker Image - Build and push
+        if: env.CI_NEEDS_REBUILD
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: ${{ env.DOCKERPATH }}
+          tags: ${{ steps.meta.outputs.tags }}
+          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -7,11 +7,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/llnl/gplasdi/lasdi_env:latest
-      options: --user 1001 --privileged
-      volumes:
-        - /mnt:/mnt
+    # container:
+    #   image: ghcr.io/llnl/gplasdi/lasdi_env:latest
+    #   options: --user 1001 --privileged
+    #   volumes:
+    #     - /mnt:/mnt
     permissions:
       contents: write
     steps:
@@ -20,15 +20,15 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - uses: actions/checkout@v4
-    - name: check autoapi.extension
-      run: |
-          python -m autoapi.extension
+    # - name: check autoapi.extension
+    #   run: |
+    #       python -m autoapi.extension
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
-        build-command: "sphinx-build -b html . build"
-        pre-build-command: "pip install sphinx-autoapi sphinx_rtd_theme"
+        build-command: "sphinx-build -b html source build"
+        pre-build-command: "pip install --upgrade pip && pip install sphinx-autoapi sphinx_rtd_theme"
       # run: |
       #     sphinx-build --version
       #     cd ${GITHUB_WORKSPACE}/docs

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -24,7 +24,10 @@ jobs:
       run: |
           python -m autoapi.extension
     - name: Build HTML
-      uses: ammaraskar/sphinx-action@master
+      # uses: ammaraskar/sphinx-action@master
+      run: |
+          sphinx-build --version
+          sphinx-build -b html source/ build/
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -36,17 +36,15 @@ jobs:
       #     sphinx-build -b html source/ build/
     - name: check resulting files
       run: |
-          ls ${GITHUB_WORKSPACE}/docs/
           ls ${GITHUB_WORKSPACE}/docs/build
-          ls ${GITHUB_WORKSPACE}/docs/build/html
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: html-docs
-        path: docs/build/html/
+        path: docs/build/
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       # if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/build/html
+        publish_dir: docs/build

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -41,7 +41,7 @@ jobs:
         path: docs/build/
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/main'
+      # if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,13 +1,24 @@
 name: "Sphinx: Render docs"
 
-on: push
+# on: push
+on:
+  workflow_call:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/llnl/gplasdi/lasdi_env:latest
+      options: --user 1001 --privileged
+      volumes:
+        - /mnt:/mnt
     permissions:
       contents: write
     steps:
+    - name: Cancel previous runs
+      uses: styfle/cancel-workflow-action@0.11.0
+      with:
+        access_token: ${{ github.token }}
     - uses: actions/checkout@v4
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -41,7 +41,7 @@ jobs:
         path: docs/build/
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
-      # if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -34,6 +34,11 @@ jobs:
       #     cd ${GITHUB_WORKSPACE}/docs
       #     mkdir build
       #     sphinx-build -b html source/ build/
+    - name: check resulting files
+      run: |
+          ls ${GITHUB_WORKSPACE}/docs/
+          ls ${GITHUB_WORKSPACE}/docs/build
+          ls ${GITHUB_WORKSPACE}/docs/build/html
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -20,9 +20,6 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - uses: actions/checkout@v4
-    # - name: check autoapi.extension
-    #   run: |
-    #       python -m autoapi.extension
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master
       with:
@@ -44,7 +41,7 @@ jobs:
         path: docs/build/
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
-      # if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,0 +1,24 @@
+name: "Sphinx: Render docs"
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build HTML
+      uses: ammaraskar/sphinx-action@master
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-docs
+        path: docs/build/html/
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      # if: github.ref == 'refs/heads/main'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/build/html

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -24,10 +24,16 @@ jobs:
       run: |
           python -m autoapi.extension
     - name: Build HTML
-      # uses: ammaraskar/sphinx-action@master
-      run: |
-          sphinx-build --version
-          sphinx-build -b html source/ build/
+      uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"
+        build-command: "sphinx-build -b html . build"
+        pre-build-command: "pip install sphinx-autoapi sphinx_rtd_theme"
+      # run: |
+      #     sphinx-build --version
+      #     cd ${GITHUB_WORKSPACE}/docs
+      #     mkdir build
+      #     sphinx-build -b html source/ build/
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - uses: actions/checkout@v4
+    - name: check autoapi.extension
+      run: |
+          python -m autoapi.extension
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master
     - name: Upload artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ examples/results
 examples/checkpoint
 *.npy
 build
+docs/build

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ This python package requires updated prerequistes:
 "scipy>=1.13.1",
 "pyyaml>=6.0",
 "matplotlib>=3.8.4",
-"argparse>=1.4.0"
+"argparse>=1.4.0",
+"h5py"
 ```
 
 ### For LLNL LC Lassen users

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,18 +11,19 @@ WORKDIR /$ENVDIR
 RUN sudo apt-get install -yq git
 RUN sudo apt-get install --no-install-recommends -yq make gcc gfortran libssl-dev cmake
 RUN sudo apt-get install -yq libopenblas-dev libmpich-dev libblas-dev liblapack-dev libscalapack-mpi-dev libhdf5-mpi-dev hdf5-tools
-RUN sudo apt-get install -yq vim
+# RUN sudo apt-get install -yq vim
 RUN sudo apt-get install -yq git-lfs
-RUN sudo apt-get install -yq valgrind
+# RUN sudo apt-get install -yq valgrind
 RUN sudo apt-get install -yq wget
-RUN sudo apt-get install -yq astyle
+# RUN sudo apt-get install -yq astyle
 
 # install python
 RUN sudo apt-get install -yq python3
 RUN sudo apt-get install -yq python3-dev
 RUN sudo apt-get install -yq python3-pip
-RUN sudo pip3 install --upgrade pip
-RUN sudo pip3 install sphinx-autoapi sphinx_rtd_theme
+RUN sudo apt-get install python-is-python3
+RUN sudo python -m pip install --upgrade pip
+RUN sudo python -m pip install sphinx-autoapi sphinx_rtd_theme
 #RUN sudo pip3 install numpy scipy argparse tables PyYAML h5py pybind11 pytest mpi4py merlin
 #
 RUN sudo apt-get clean -q

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN sudo apt-get install -yq python3-dev
 RUN sudo apt-get install -yq python3-pip
 RUN sudo apt-get install python-is-python3
 RUN sudo python -m pip install --upgrade pip
-RUN sudo python -m pip install sphinx-autoapi sphinx_rtd_theme
+RUN sudo python -m pip install sphinx sphinx-autoapi sphinx_rtd_theme
 #RUN sudo pip3 install numpy scipy argparse tables PyYAML h5py pybind11 pytest mpi4py merlin
 #
 RUN sudo apt-get clean -q

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:22.04
+
+ENV ENVDIR=env
+
+# install sudo
+RUN apt-get -yq update && apt-get -yq install sudo
+
+WORKDIR /$ENVDIR
+
+# install packages
+RUN sudo apt-get install -yq git
+RUN sudo apt-get install --no-install-recommends -yq make gcc gfortran libssl-dev cmake
+RUN sudo apt-get install -yq libopenblas-dev libmpich-dev libblas-dev liblapack-dev libscalapack-mpi-dev libhdf5-mpi-dev hdf5-tools
+RUN sudo apt-get install -yq vim
+RUN sudo apt-get install -yq git-lfs
+RUN sudo apt-get install -yq valgrind
+RUN sudo apt-get install -yq wget
+RUN sudo apt-get install -yq astyle
+
+# install python
+RUN sudo apt-get install -yq python3
+RUN sudo apt-get install -yq python3-dev
+RUN sudo apt-get install -yq python3-pip
+RUN sudo pip3 install --upgrade pip
+RUN sudo pip3 install sphinx-autoapi sphinx_rtd_theme
+#RUN sudo pip3 install numpy scipy argparse tables PyYAML h5py pybind11 pytest mpi4py merlin
+#
+RUN sudo apt-get clean -q
+
+# create and switch to a user
+ENV USERNAME=test
+RUN echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+RUN useradd --no-log-init -u 1001 --create-home --shell /bin/bash $USERNAME
+RUN adduser $USERNAME sudo
+USER $USERNAME
+WORKDIR /home/$USERNAME

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,8 +12,8 @@ sys.path.insert(0, os.path.abspath('..'))
 sys.path.insert(0, os.path.abspath('../../src'))
 
 project = 'LaSDI'
-copyright = '2024, Kevin Chung'
-author = 'Kevin Chung'
+copyright = '2023-2024, Lawrence Livermore National Security, LLC and other LaSDI project developers.'
+author = 'Christophe Bonneville, Kevin Chung, Youngsoo Choi'
 release = '2.0'
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,42 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os, sys
+sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../../src'))
+
+project = 'LaSDI'
+copyright = '2024, Kevin Chung'
+author = 'Kevin Chung'
+release = '2.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'autoapi.extension',
+    'sphinx.ext.napoleon',
+]
+
+autoapi_dirs = ['../../src']
+ 
+napoleon_google_docstring = False
+napoleon_use_param = False
+napoleon_use_ivar = True
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,5 +15,12 @@ It also supports parametric interpolation of latent dynamics according to uncert
    :maxdepth: 2
    :caption: Contents:
 
-   lasdi
+References
+===================
 
+* Fries, William D., Xiaolong He, and Youngsoo Choi. "LaSDI: Parametric latent space dynamics identification." Computer Methods in Applied Mechanics and Engineering 399 (2022): 115436.
+* He, Xiaolong, Youngsoo Choi, William D. Fries, Jonathan L. Belof, and Jiun-Shyan Chen. "gLaSDI: Parametric physics-informed greedy latent space dynamics identification." Journal of Computational Physics 489 (2023): 112267.
+* Tran, April, Xiaolong He, Daniel A. Messenger, Youngsoo Choi, and David M. Bortz. "Weak-form latent space dynamics identification." Computer Methods in Applied Mechanics and Engineering 427 (2024): 116998.
+* Park, Jun Sur Richard, Siu Wun Cheung, Youngsoo Choi, and Yeonjong Shin. "tLaSDI: Thermodynamics-informed latent space dynamics identification." arXiv preprint arXiv:2403.05848 (2024).
+* Bonneville, Christophe, Youngsoo Choi, Debojyoti Ghosh, and Jonathan L. Belof. "Gplasdi: Gaussian process-based interpretable latent space dynamics identification through deep autoencoder." Computer Methods in Applied Mechanics and Engineering 418 (2024): 116535.
+* He, Xiaolong, April Tran, David M. Bortz, and Youngsoo Choi. "Physics-informed active learning with simultaneous weak-form latent space dynamics identification." arXiv preprint arXiv:2407.00337 (2024).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,10 +6,10 @@
 LaSDI documentation
 ===================
 
-Add your content using ``reStructuredText`` syntax. See the
-`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
-documentation for details.
-
+LaSDI is a light-weight python package for Latent Space Dynamics Identification.
+LaSDI maps full-order PDE solutions to a latent space using autoencoders and learns the system of ODEs governing the latent space dynamics.
+By interpolating and solving the ODE system in the reduced latent space, fast and accurate ROM predictions can be made by feeding the predicted latent space dynamics into the decoder.
+It also supports parametric interpolation of latent dynamics according to uncertainties evaluated via Gaussian process.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,19 @@
+.. LaSDI documentation master file, created by
+   sphinx-quickstart on Wed Oct 16 22:11:53 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+LaSDI documentation
+===================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   lasdi
+

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -35,7 +35,7 @@
     "from lasdi.latent_space import Autoencoder, initial_condition_latent\n",
     "from lasdi.postprocess import compute_errors\n",
     "\n",
-    "filename = 'lasdi_09_11_2024_20_20.npy'"
+    "filename = 'lasdi_09_18_2024_20_51.npy'"
    ]
   },
   {
@@ -113,8 +113,7 @@
     "n_z = autoencoder_param['fc' + str(n_hidden + 1) + '_e.weight'].shape[0]\n",
     "\n",
     "autoencoder.load_state_dict(autoencoder_param)\n",
-    "Z = autoencoder.encoder(X_train)\n",
-    "coefs = sindy.calibrate(Z, physics.dt, compute_loss=False, numpy=True)\n",
+    "coefs = restart_file['trainer']['best_coefs']\n",
     "gp_dictionnary = fit_gps(param_space.train_space, coefs)\n",
     "\n",
     "n_coef = sindy.ncoefs\n",

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "d67dad03-9d76-4891-82ff-7e19d1369a24",
    "metadata": {},
    "outputs": [],
@@ -46,6 +46,7 @@
     "trainer, param_space, physics, autoencoder, sindy = initialize_trainer(config)\n",
     "\n",
     "# generate initial training/test data\n",
+    "pick_samples(trainer, config)\n",
     "run_samples(trainer, config)\n",
     "# initial training given training data\n",
     "trainer.train()\n",
@@ -77,7 +78,7 @@
    "outputs": [],
    "source": [
     "# Specify the restart file you have.\n",
-    "filename = 'lasdi_09_18_2024_20_51.npy'\n",
+    "filename = 'lasdi_10_01_2024_17_09.npy'\n",
     "\n",
     "import yaml\n",
     "from lasdi.workflow import initialize_trainer\n",
@@ -110,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "dcdac0c2",
    "metadata": {},
    "outputs": [],

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -16,13 +16,57 @@
   },
   {
    "cell_type": "markdown",
+   "id": "493f4313",
+   "metadata": {},
+   "source": [
+    "# Overall workflow and training\n",
+    "\n",
+    "Data generation/training can be performed by built-in executable `lasdi`. For this example of Burgers 1D equation, you can simply run on command-line terminal:\n",
+    "```\n",
+    "lasdi burgers1d.yml\n",
+    "```\n",
+    "\n",
+    "The workflow can be also manually constructed for those who prefer python scripts and for prototyping. Following code snippets show the high-level view of the workflow in the executable `lasdi`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ead8f2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from lasdi.workflow import initialize_trainer, run_samples, pick_samples\n",
+    "\n",
+    "cfg_file = 'burgers1d.yml'\n",
+    "with open(cfg_file, 'r') as f:\n",
+    "    config = yaml.safe_load(f)\n",
+    "\n",
+    "trainer, param_space, physics, autoencoder, sindy = initialize_trainer(config)\n",
+    "\n",
+    "# generate initial training/test data\n",
+    "run_samples(trainer, config)\n",
+    "# initial training given training data\n",
+    "trainer.train()\n",
+    "\n",
+    "while (trainer.restart_iter < trainer.max_iter):\n",
+    "    if (trainer.restart_iter <= trainer.max_greedy_iter):\n",
+    "        # perform greedy sampling to pick up new samples\n",
+    "        pick_samples(trainer, config)\n",
+    "        # update training data with newly picked samples\n",
+    "        run_samples(trainer, config)\n",
+    "\n",
+    "    # train over given training data\n",
+    "    trainer.train()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cfffced1",
    "metadata": {},
    "source": [
-    "We assume all data generation/training is complete. If not done yet, please run on the terminal:\n",
-    "```\n",
-    "lasdi burgers1d.yml\n",
-    "```"
+    "If you ran the command instead, a restart file is saved at the end of the training, which can be loaded for post-processing:"
    ]
   },
   {
@@ -32,27 +76,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lasdi.latent_space import Autoencoder, initial_condition_latent\n",
-    "from lasdi.postprocess import compute_errors\n",
+    "# Specify the restart file you have.\n",
+    "filename = 'lasdi_09_18_2024_20_51.npy'\n",
     "\n",
-    "filename = 'lasdi_09_18_2024_20_51.npy'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e1dfd2b6",
-   "metadata": {},
-   "source": [
-    "Initialize physics solver, according to the config file `burgers1d.yml`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "68f93c32",
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import yaml\n",
     "from lasdi.workflow import initialize_trainer\n",
     "from lasdi.param import ParameterSpace\n",
@@ -67,26 +93,77 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "42758da9",
+   "metadata": {},
+   "source": [
+    "# Post-processing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cf48489",
+   "metadata": {},
+   "source": [
+    "Load data for post-processing:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef6a1685",
+   "id": "dcdac0c2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lasdi.gp import fit_gps\n",
+    "coefs = trainer.best_coefs\n",
+    "X_train = trainer.X_train\n",
+    "X_test = trainer.X_test\n",
     "\n",
-    "autoencoder_param = restart_file['latent_space']['autoencoder_param']\n",
+    "param_train = param_space.train_space\n",
+    "param_grid = param_space.test_space\n",
+    "test_meshgrid = param_space.test_meshgrid\n",
+    "test_grid_sizes = param_space.test_grid_sizes\n",
+    "n_init = param_space.n_init\n",
     "\n",
+    "n_a_grid, n_w_grid = test_grid_sizes\n",
+    "a_grid, w_grid = test_meshgrid\n",
+    "\n",
+    "t_grid = physics.t_grid\n",
+    "x_grid = physics.x_grid\n",
+    "t_mesh, x_mesh = np.meshgrid(t_grid, x_grid)\n",
+    "Dt, Dx = physics.dt, physics.dx\n",
+    "\n",
+    "time_dim, space_dim = t_grid.shape[0], x_grid.shape[0]\n",
+    "\n",
+    "n_coef = sindy.ncoefs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2b6e720",
+   "metadata": {},
+   "source": [
+    "They can be also loaded directly from restart file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e796b0bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coefs = restart_file['trainer']['best_coefs']\n",
     "X_train = restart_file['trainer']['X_train']\n",
+    "X_test = restart_file['trainer']['X_test']\n",
     "\n",
     "paramspace_dict = restart_file['parameters']\n",
     "param_train = paramspace_dict['train_space']\n",
     "param_grid = paramspace_dict['test_space']\n",
     "test_meshgrid = paramspace_dict['test_meshgrid']\n",
     "test_grid_sizes = paramspace_dict['test_grid_sizes']\n",
-    "\n",
     "n_init = paramspace_dict['n_init']\n",
-    "n_samples = 20\n",
+    "\n",
     "n_a_grid, n_w_grid = test_grid_sizes\n",
     "a_grid, w_grid = test_meshgrid\n",
     "\n",
@@ -97,33 +174,38 @@
     "Dt = physics_dict['dt']\n",
     "Dx = physics_dict['dx']\n",
     "\n",
-    "# total_time = bglasdi_results['total_time']\n",
-    "# start_train_phase = bglasdi_results['start_train_phase']\n",
-    "# start_fom_phase = bglasdi_results['start_fom_phase']\n",
-    "# end_train_phase = bglasdi_results['end_train_phase']\n",
-    "# end_fom_phase = bglasdi_results['end_fom_phase']\n",
-    "\n",
-    "data_test = np.load('data/data_test.npy', allow_pickle = True).item()\n",
-    "X_test = data_test['X_test']\n",
-    "\n",
     "time_dim, space_dim = t_grid.shape[0], x_grid.shape[0]\n",
+    "n_coef = restart_file['latent_dynamics']['ncoefs']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1262a0c3",
+   "metadata": {},
+   "source": [
+    "## Gaussian-process uncertainty evaluation\n",
+    "We evaluated the uncertainties of latent dynamics coefficients over 2d parameter space, with samples from GP prediction:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef6a1685",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.gp import fit_gps\n",
+    "from lasdi.gplasdi import sample_roms, average_rom\n",
+    "from lasdi.postprocess import compute_errors\n",
+    "from lasdi.gp import eval_gp\n",
     "\n",
-    "n_hidden = len(autoencoder_param.keys()) // 4 - 1\n",
-    "hidden_units = [autoencoder_param['fc' + str(i + 1) + '_e.weight'].shape[0] for i in range(n_hidden)]\n",
-    "n_z = autoencoder_param['fc' + str(n_hidden + 1) + '_e.weight'].shape[0]\n",
+    "n_samples = 20\n",
+    "autoencoder.cpu()\n",
     "\n",
-    "autoencoder.load_state_dict(autoencoder_param)\n",
-    "coefs = restart_file['trainer']['best_coefs']\n",
     "gp_dictionnary = fit_gps(param_space.train_space, coefs)\n",
     "\n",
-    "n_coef = sindy.ncoefs\n",
-    "\n",
-    "from lasdi.gplasdi import sample_roms, average_rom\n",
     "Zis_samples = sample_roms(autoencoder, physics, sindy, gp_dictionnary, param_grid, n_samples)\n",
     "Zis_mean = average_rom(autoencoder, physics, sindy, gp_dictionnary, param_grid)\n",
-    "\n",
-    "print(Zis_mean.shape)\n",
-    "print(Zis_samples.shape)\n",
     "\n",
     "X_pred_mean = autoencoder.decoder(torch.Tensor(Zis_mean)).detach().numpy()\n",
     "X_pred_samples = autoencoder.decoder(torch.Tensor(Zis_samples)).detach().numpy()\n",
@@ -139,11 +221,15 @@
     "avg_rel_error = avg_rel_error.reshape([n_w_grid, n_a_grid]).T\n",
     "max_std = max_std.reshape([n_w_grid, n_a_grid]).T\n",
     "\n",
-    "print(avg_rel_error.shape)\n",
-    "print(max_std.shape)\n",
-    "\n",
-    "from lasdi.gp import eval_gp\n",
     "gp_pred_mean, gp_pred_std = eval_gp(gp_dictionnary, param_grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f31c964",
+   "metadata": {},
+   "source": [
+    "# Visualization"
    ]
   },
   {

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -35,8 +35,7 @@
     "from lasdi.latent_space import Autoencoder, initial_condition_latent\n",
     "from lasdi.postprocess import compute_errors\n",
     "\n",
-    "date = '08_28_2024_20_46'\n",
-    "bglasdi_results = np.load('results/bglasdi_' + date + '.npy', allow_pickle = True).item()"
+    "filename = 'lasdi_09_11_2024_20_20.npy'"
    ]
   },
   {
@@ -55,17 +54,16 @@
    "outputs": [],
    "source": [
     "import yaml\n",
-    "from lasdi.workflow import initialize_physics, initialize_latent_space, ld_dict\n",
+    "from lasdi.workflow import initialize_trainer\n",
     "from lasdi.param import ParameterSpace\n",
     "\n",
     "cfg_file = 'burgers1d.yml'\n",
     "with open(cfg_file, 'r') as f:\n",
     "    config = yaml.safe_load(f)\n",
     "\n",
-    "param_space = ParameterSpace(config)\n",
-    "physics = initialize_physics(param_space, config)\n",
-    "autoencoder = initialize_latent_space(physics, config)\n",
-    "sindy = ld_dict[config['latent_dynamics']['type']](autoencoder.n_z, physics.nt, config['latent_dynamics'])"
+    "restart_file = np.load(filename, allow_pickle=True).item()\n",
+    "\n",
+    "trainer, param_space, physics, autoencoder, sindy = initialize_trainer(config, restart_file)"
    ]
   },
   {
@@ -75,16 +73,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "autoencoder_param = bglasdi_results['autoencoder_param']\n",
+    "from lasdi.gp import fit_gps\n",
     "\n",
-    "X_train = bglasdi_results['final_X_train']\n",
-    "coefs = bglasdi_results['coefs']\n",
-    "gp_dictionnary = bglasdi_results['gp_dictionnary']\n",
-    "fd_type = bglasdi_results['latent_dynamics']['fd_type']\n",
+    "autoencoder_param = restart_file['latent_space']['autoencoder_param']\n",
     "\n",
-    "paramspace_dict = bglasdi_results['parameters']\n",
-    "param_train = paramspace_dict['final_param_train']\n",
-    "param_grid = paramspace_dict['param_grid']\n",
+    "X_train = restart_file['trainer']['X_train']\n",
+    "\n",
+    "paramspace_dict = restart_file['parameters']\n",
+    "param_train = paramspace_dict['train_space']\n",
+    "param_grid = paramspace_dict['test_space']\n",
     "test_meshgrid = paramspace_dict['test_meshgrid']\n",
     "test_grid_sizes = paramspace_dict['test_grid_sizes']\n",
     "\n",
@@ -93,7 +90,7 @@
     "n_a_grid, n_w_grid = test_grid_sizes\n",
     "a_grid, w_grid = test_meshgrid\n",
     "\n",
-    "physics_dict = bglasdi_results['physics']\n",
+    "physics_dict = restart_file['physics']\n",
     "t_grid = physics_dict['t_grid']\n",
     "x_grid = physics_dict['x_grid']\n",
     "t_mesh, x_mesh = np.meshgrid(t_grid, x_grid)\n",
@@ -116,6 +113,9 @@
     "n_z = autoencoder_param['fc' + str(n_hidden + 1) + '_e.weight'].shape[0]\n",
     "\n",
     "autoencoder.load_state_dict(autoencoder_param)\n",
+    "Z = autoencoder.encoder(X_train)\n",
+    "coefs = sindy.calibrate(Z, physics.dt, compute_loss=False, numpy=True)\n",
+    "gp_dictionnary = fit_gps(param_space.train_space, coefs)\n",
     "\n",
     "n_coef = sindy.ncoefs\n",
     "\n",

--- a/examples/burgers1d.offline.bash
+++ b/examples/burgers1d.offline.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+# First stage will be RunSamples, which will produce parameter point files in hdf5 format.
+# Each lasdi command will save a restart file, which will be read on the next lasdi command.
+# So all stages are run by the same command, directed differently by the restart file.
+lasdi burgers1d.offline.yml
+
+# Run/save FOM solution with offline FOM solver.
+burgers1d burgers1d.offline.yml
+
+# Collect FOM solution.
+lasdi burgers1d.offline.yml
+
+# Train latent dynamics model.
+lasdi burgers1d.offline.yml
+
+for k in {0..8}
+do
+    # Pick a new sample from greedy sampling
+    lasdi burgers1d.offline.yml
+
+    # A cycle of RunSamples/offline FOM/CollectSamples
+    lasdi burgers1d.offline.yml
+    burgers1d burgers1d.offline.yml
+    lasdi burgers1d.offline.yml
+
+    # Train latent dynamics model.
+    lasdi burgers1d.offline.yml
+done

--- a/examples/burgers1d.offline.bash
+++ b/examples/burgers1d.offline.bash
@@ -1,29 +1,48 @@
 #!/usr/bin/bash
 
-# First stage will be RunSamples, which will produce parameter point files in hdf5 format.
+check_result () {
+  # $1: Result output of the previous command ($?)
+  # $2: Name of the previous command
+  if [ $1 -eq 0 ]; then
+      echo "$2 succeeded"
+  else
+      echo "$2 failed"
+      exit -1
+  fi
+}
+
+# First stage will be PickSample, which will produce parameter point files in hdf5 format.
 # Each lasdi command will save a restart file, which will be read on the next lasdi command.
 # So all stages are run by the same command, directed differently by the restart file.
 lasdi burgers1d.offline.yml
+check_result $? initial-picksample
 
 # Run/save FOM solution with offline FOM solver.
 burgers1d burgers1d.offline.yml
+check_result $? initial-runsample
 
 # Collect FOM solution.
 lasdi burgers1d.offline.yml
+check_result $? initial-collect
 
 # Train latent dynamics model.
 lasdi burgers1d.offline.yml
+check_result $? initial-train
 
 for k in {0..8}
 do
     # Pick a new sample from greedy sampling
     lasdi burgers1d.offline.yml
+    check_result $? pick-sample
 
-    # A cycle of RunSamples/offline FOM/CollectSamples
-    lasdi burgers1d.offline.yml
+    # A cycle of offline FOM/CollectSamples
     burgers1d burgers1d.offline.yml
+    check_result $? run-sample
+
     lasdi burgers1d.offline.yml
+    check_result $? collect-sample
 
     # Train latent dynamics model.
     lasdi burgers1d.offline.yml
+    check_result $? train
 done

--- a/examples/burgers1d.offline.yml
+++ b/examples/burgers1d.offline.yml
@@ -1,0 +1,61 @@
+lasdi:
+  type: gplasdi
+  gplasdi:
+    # device: mps
+    n_samples: 20
+    lr: 0.001
+    max_iter: 2000
+    n_iter: 200
+    max_greedy_iter: 2000
+    ld_weight: 0.1
+    coef_weight: 1.e-6
+    path_checkpoint: checkpoint
+    path_results: results
+
+workflow:
+  use_restart: true
+  restart_file: restarts/burgers1d.restart.npy
+  offline_greedy_sampling:
+    train_param_file: sampling/new_train.burgers1d.h5
+    test_param_file: sampling/new_test.burgers1d.h5
+    train_sol_file: sampling/new_Xtrain.burgers1d.h5
+    test_sol_file: sampling/new_Xtest.burgers1d.h5
+
+parameter_space:
+  parameters:
+    - name: a
+      min: 0.7
+      max: 0.9
+      test_space_type: uniform
+      sample_size: 11
+      log_scale: false
+    - name: w
+      min: 0.9
+      max: 1.1
+      test_space_type: uniform
+      sample_size: 11
+      log_scale: false
+  test_space:
+    type: grid
+
+latent_space:
+  type: ae
+  ae:
+    hidden_units: [100]
+    latent_dimension: 5
+
+latent_dynamics:
+  type: sindy
+  sindy:
+    fd_type: sbp12
+    coef_norm_order: fro
+
+physics:
+  type: burgers1d
+  burgers1d:
+    offline_driver: true
+    number_of_timesteps: 1001
+    simulation_time: 1.
+    grid_size: [1001]
+    xmin: -3.
+    xmax: 3.

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -12,6 +12,10 @@ lasdi:
     path_checkpoint: checkpoint
     path_results: results
 
+workflow:
+  use_restart: true
+  restart_file: restarts/burgers1d.restart.npy
+
 parameter_space:
   parameters:
     - name: a

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -7,14 +7,19 @@ lasdi:
     n_iter: 28000
     n_greedy: 2000
     max_greedy_iter: 28000
-    sindy_weight: 0.1
+    ld_weight: 0.1
     coef_weight: 1.e-6
     path_checkpoint: checkpoint
     path_results: results
 
 workflow:
-  use_restart: true
+  use_restart: false
   restart_file: restarts/burgers1d.restart.npy
+  offline_greedy_sampling:
+    train_param_file: sampling/new_train.burgers1d.h5
+    test_param_file: sampling/new_test.burgers1d.h5
+    train_sol_file: sampling/new_Xtrain.burgers1d.h5
+    test_sol_file: sampling/new_Xtest.burgers1d.h5
 
 parameter_space:
   parameters:
@@ -56,6 +61,7 @@ initial_train:
 physics:
   type: burgers1d
   burgers1d:
+    offline_driver: false
     number_of_timesteps: 1001
     simulation_time: 1.
     grid_size: [1001]

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -4,8 +4,8 @@ lasdi:
     # device: mps
     n_samples: 20
     lr: 0.001
-    n_iter: 28000
-    n_greedy: 2000
+    max_iter: 28000
+    n_iter: 2000
     max_greedy_iter: 28000
     ld_weight: 0.1
     coef_weight: 1.e-6
@@ -52,11 +52,6 @@ latent_dynamics:
   sindy:
     fd_type: sbp12
     coef_norm_order: fro
-
-# TODO(kevin): temporary placeholder
-initial_train:
-  train_data: data/data_train.npy
-  test_data: data/data_test.npy
 
 physics:
   type: burgers1d

--- a/examples/template_training.ipynb
+++ b/examples/template_training.ipynb
@@ -1,0 +1,510 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d31d3171",
+   "metadata": {},
+   "source": [
+    "# Template for autoencoder prototyping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d67dad03-9d76-4891-82ff-7e19d1369a24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import numpy as np\n",
+    "from matplotlib.colors import LinearSegmentedColormap\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.animation as animation\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Name for the case\n",
+    "name = 'template'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fceceb92",
+   "metadata": {},
+   "source": [
+    "## Hyper-parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b05f7c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = 1.0e-5\n",
+    "ae_weight = 1e0\n",
+    "sindy_weight = 1.e-6\n",
+    "coef_weight= 1.e-9\n",
+    "lr = 1e-5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55bc1410",
+   "metadata": {},
+   "source": [
+    "## Training data\n",
+    "\n",
+    "- Consider we only have one time-series simulation.\n",
+    "- suppose we have grid of size (20x30) points.\n",
+    "- solution is a 2-dimensional vector (on each grid point)\n",
+    "- A simulation of 50 time steps.\n",
+    "- the first index of snapshot array should be timestep.\n",
+    "- we consider dof as solution dimension, and number of particles as grid size.\n",
+    "\n",
+    "Can load other data files for your custom autoencoder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca3062c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ntrain = 1\n",
+    "sol_dim = 2\n",
+    "grid_dim = [20,30]\n",
+    "nt = 50\n",
+    "\n",
+    "# number of cases x number of time step x solution dimension x grid size\n",
+    "snapshots = np.random.rand(ntrain, nt, sol_dim, grid_dim[0], grid_dim[1])\n",
+    "X_train = torch.Tensor(snapshots)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b6241c5",
+   "metadata": {},
+   "source": [
+    "## Setting up a physics wrapper.\n",
+    "\n",
+    "You can choose from `lasdi.physics` module, or create a custom physics model. Following snippet is an example with some necessary specifications."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a0349ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.physics import Physics\n",
+    "\n",
+    "class CustomPhysicsModel(Physics):\n",
+    "    def __init__(self):\n",
+    "        self.dim = 2\n",
+    "        self.nt = nt\n",
+    "        self.dt = dt\n",
+    "        self.qdim = sol_dim\n",
+    "        self.grid_size = grid_dim\n",
+    "        self.qgrid_size = [sol_dim] + grid_dim\n",
+    "\n",
+    "        ''' Set up a grid as you see fit. '''\n",
+    "        self.x_grid = np.zeros([self.dim] + self.grid_size)\n",
+    "        xg = np.linspace(0., 1., grid_dim[1])\n",
+    "        yg = np.linspace(0., 1., grid_dim[0])\n",
+    "        self.x_grid[0], self.x_grid[1] = np.meshgrid(xg, yg)\n",
+    "        return\n",
+    "    \n",
+    "    ''' See lasdi.physics.Physics class for necessary subroutines '''\n",
+    "\n",
+    "physics = CustomPhysicsModel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9996b792",
+   "metadata": {},
+   "source": [
+    "## Setting up autoencoder\n",
+    "\n",
+    "You can choose from `lasdi.latent_space` module, or create a custom autoencoder. The snippet below uses a built-in `Autoencoder` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c53127b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.latent_space import Autoencoder\n",
+    "\n",
+    "n_train = 1\n",
+    "hidden_units = [3000, 300, 300, 100, 100, 30]\n",
+    "# latent space dimension\n",
+    "n_z = 5\n",
+    "print(physics.grid_size, hidden_units, n_z)\n",
+    "\n",
+    "# I think these options are straightforward.\n",
+    "ae_cfg = {'hidden_units': hidden_units, 'latent_dimension': n_z, 'activation': 'softplus'}\n",
+    "\n",
+    "ae = Autoencoder(physics, ae_cfg)\n",
+    "best_loss = np.Inf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0ea7a53",
+   "metadata": {},
+   "source": [
+    "## Setting up latent dynamics\n",
+    "\n",
+    "Similarly, we either choose a latent dynamics model from `lasdi.latent_dynamics` module or create a custom model. Here we use `SINDy` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad4ae3ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.latent_dynamics.sindy import SINDy\n",
+    "\n",
+    "sindy_options = {'sindy': {'fd_type': 'sbp12'}} # finite-difference operator for computing time derivative of latent trajectory.\n",
+    "ld = SINDy(ae.n_z, physics.nt, sindy_options)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5d98899",
+   "metadata": {},
+   "source": [
+    "## Training: (1) Running a custom optimization process"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36bacfa9",
+   "metadata": {},
+   "source": [
+    "Set up optimizer and loss term"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31de72b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer = torch.optim.Adam(ae.parameters(), lr = lr)\n",
+    "MSE = torch.nn.MSELoss()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55cfb184",
+   "metadata": {},
+   "source": [
+    "Set up device: `'cuda'`, `'mps'` (apple) or `'cpu'`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35cd5db2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = 'cpu'\n",
+    "d_ae = ae.to(device)\n",
+    "d_Xtrain = X_train.to(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65bc550a",
+   "metadata": {},
+   "source": [
+    "This is a part of GPLaSDI training procedure, where the training is executed without on-the-fly sampling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff367763",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_iter = 10\n",
+    "save_interval = 1\n",
+    "hist_file = '%s.loss_history.txt' % name\n",
+    "\n",
+    "loss_hist = np.zeros([n_iter, 4])\n",
+    "grad_hist = np.zeros([n_iter, 4])\n",
+    "for iter in range(n_iter):\n",
+    "    optimizer.zero_grad()\n",
+    "    d_ae = ae.to(device)\n",
+    "    d_Z = d_ae.encoder(d_Xtrain)\n",
+    "    d_Xpred = d_ae.decoder(d_Z)\n",
+    "    Z = d_Z.cpu()\n",
+    "\n",
+    "    loss_ae = MSE(d_Xtrain, d_Xpred)\n",
+    "    coefs, loss_sindy, loss_coef = ld.calibrate(Z, physics.dt, compute_loss=True, numpy=True)\n",
+    "\n",
+    "    max_coef = np.abs(np.array(coefs)).max()\n",
+    "    loss = ae_weight * loss_ae + sindy_weight * loss_sindy / n_train + coef_weight * loss_coef / n_train\n",
+    "\n",
+    "    loss_hist[iter] = [loss.item(), loss_ae.item(), loss_sindy.item(), loss_coef.item()]\n",
+    "\n",
+    "    loss.backward()\n",
+    "\n",
+    "    optimizer.step()\n",
+    "\n",
+    "    if ((loss.item() < best_loss) and (iter % save_interval == 0)):\n",
+    "        torch.save(d_ae.cpu().state_dict(), './%s_checkpoint.pt' % name)\n",
+    "        best_loss = loss.item()\n",
+    "\n",
+    "    # print(\"Iter: %05d/%d, Loss: %.5e\" % (iter + 1, n_iter, loss.item()))\n",
+    "    print(\"Iter: %05d/%d, Loss: %.5e, Loss AE: %.5e, Loss SI: %.5e, Loss COEF: %.5e, max|c|: %.5e\"\n",
+    "            % (iter + 1, n_iter, loss.item(), loss_ae.item(), loss_sindy.item(), loss_coef.item(), max_coef))\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "015d02f5",
+   "metadata": {},
+   "source": [
+    "Save the history and the trained parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb293bb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.savetxt('%s.loss_history.txt' % name, loss_hist)\n",
+    "\n",
+    "if (loss.item() < best_loss):\n",
+    "    torch.save(d_ae.cpu().state_dict(), './%s_checkpoint.pt' % name)\n",
+    "    best_loss = loss.item()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97f719d3",
+   "metadata": {},
+   "source": [
+    "Load a checkpoint and re-evaluate the losses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00f7da25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state_dict = torch.load('%s_checkpoint.pt' % name)\n",
+    "ae.load_state_dict(state_dict)\n",
+    "ae.eval()\n",
+    "d_ae = ae.to(device)\n",
+    "d_Z = d_ae.encoder(d_Xtrain)\n",
+    "d_Xpred = d_ae.decoder(d_Z)\n",
+    "Z = d_Z.cpu()\n",
+    "print(Z.shape)\n",
+    "\n",
+    "loss_ae = MSE(d_Xtrain, d_Xpred)\n",
+    "coefs, loss_sindy, loss_coef = ld.calibrate(Z, physics.dt, compute_loss=True, numpy=True)\n",
+    "\n",
+    "max_coef = np.abs(np.array(coefs)).max()\n",
+    "loss = loss_ae + sindy_weight * loss_sindy / n_train + coef_weight * loss_coef / n_train\n",
+    "print(loss.item())\n",
+    "print(loss_ae.item())\n",
+    "print((sindy_weight * loss_sindy / n_train).item())\n",
+    "print((coef_weight * loss_coef / n_train).item())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6516cfa7",
+   "metadata": {},
+   "source": [
+    "Visualize the loss history"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d62570fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss_hist = np.loadtxt('%s.loss_history.txt' % name)\n",
+    "\n",
+    "plt.figure(1)\n",
+    "plt.loglog(loss_hist[:, 0])\n",
+    "plt.xlabel('iteration')\n",
+    "plt.ylabel('loss')\n",
+    "\n",
+    "plt.rcParams.update({'font.size': 15})\n",
+    "plt.figure(2, figsize=(8, 6))\n",
+    "plt.loglog(loss_hist[:, 1:])\n",
+    "plt.xlabel('iteration')\n",
+    "plt.ylabel('loss')\n",
+    "plt.legend([\"ae\", \"sindy\", \"coef\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82af6aa5",
+   "metadata": {},
+   "source": [
+    "Obtain the predicted solution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4692510d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tgrid = np.linspace(0, (nt-1)*dt, nt)\n",
+    "\n",
+    "d_Z = d_ae.encoder(d_Xtrain)\n",
+    "Z = d_Z.cpu().detach().numpy()\n",
+    "\n",
+    "Zpred = np.zeros([n_train, physics.nt, ae.n_z])\n",
+    "for case_idx in range(len(coefs)):\n",
+    "    Zpred[case_idx] = ld.simulate(coefs[case_idx], Z[case_idx, 0], tgrid)\n",
+    "\n",
+    "d_Zpred = torch.Tensor(Zpred).to(device)\n",
+    "X_pred = d_ae.decoder(d_Zpred).cpu().detach().numpy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38cafdda",
+   "metadata": {},
+   "source": [
+    "Plot the latent variable evolution and compare the prediction with the truth"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f178a53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colors = ['r','g','b','c','m']\n",
+    "\n",
+    "for case_idx in range(len(coefs)):\n",
+    "    plt.figure(1+case_idx, figsize=(8,6))\n",
+    "    for k, color in enumerate(colors):\n",
+    "        plt.plot(Zpred[case_idx][:, k],'-'+color)\n",
+    "        plt.plot(Z[case_idx][:, k],'--'+color)\n",
+    "    plt.ylabel('$Z$')\n",
+    "    plt.xlabel('$t$ ($\\\\times\\Delta t$)')\n",
+    "    plt.legend(['pred','truth'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfb4c0bf",
+   "metadata": {},
+   "source": [
+    "Visualization of full-order model solution.\n",
+    "Feel free to change as you see fit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da08d933",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "case_idx = 0\n",
+    "time_idx = 14\n",
+    "var_idx = 0\n",
+    "\n",
+    "truth = snapshots[case_idx, time_idx, var_idx]\n",
+    "pred = X_pred[case_idx, time_idx, var_idx]\n",
+    "\n",
+    "plt.figure(1)\n",
+    "plt.contourf(physics.x_grid[0], physics.x_grid[1], truth, 200)\n",
+    "\n",
+    "plt.figure(2)\n",
+    "plt.contourf(physics.x_grid[0], physics.x_grid[1], pred, 200)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71653612",
+   "metadata": {},
+   "source": [
+    "## Training: (2) Using built-in GPLaSDI trainer\n",
+    "\n",
+    "**Work in progress**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ad84e16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.gplasdi import BayesianGLaSDI\n",
+    "\n",
+    "trainer_options = {'n_samples': 20,         # number of samples when choosing a new parameter point. Not used in this case\n",
+    "                   'lr': lr,                # learning rate\n",
+    "                   'n_iter': 10000,         # number of iteration in training\n",
+    "                   'max_greedy_iter': 0,    # maximum iteration to perform greedy sampling. Not used in this case\n",
+    "                   'n_greedy': -1,          # frequency of greedy sampling. Not used in this case\n",
+    "                   'sindy_weight': sindy_weight, # weight for latent dynamics loss\n",
+    "                   'coef_weight': coef_weight,   # weight for latent dynamics coefficient regularization\n",
+    "                   'device': 'cpu',              # device to perform training (cpu, cuda, mps)\n",
+    "                   'path_checkpoint': 'checkpoints', # directory to save training checkpoint files\n",
+    "                   'path_results': 'results',        # directory to save training results\n",
+    "                   }\n",
+    "\n",
+    "trainer = BayesianGLaSDI(physics, ae, ld, trainer_options)\n",
+    "trainer.X_train = X_train\n",
+    "\n",
+    "trainer.train()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv_gpu",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
   "scipy>=1.10",
   "pyyaml>=6.0",
   "matplotlib>=3.8.0",
-  "argparse>=1.1"
+  "argparse>=1.1",
+  "h5py"
 ]
 
 [project.urls]
@@ -34,3 +35,4 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 lasdi = "lasdi.workflow:main [config_file]"
+burgers1d = "lasdi.physics.burgers1d:main [config_file]"

--- a/src/lasdi/enums.py
+++ b/src/lasdi/enums.py
@@ -1,8 +1,8 @@
 from enum import Enum
 
 class NextStep(Enum):
-    Initial = 1
-    Train = 2
+    Train = 1
+    PickSample = 2
     RunSample = 3
     CollectSample = 4
 

--- a/src/lasdi/enums.py
+++ b/src/lasdi/enums.py
@@ -1,13 +1,13 @@
 from enum import Enum
 
 class NextStep(Enum):
-    Train = 1
-    PickSample = 2
-    RunSample = 3
-    CollectSample = 4
+    Train           = 1
+    PickSample      = 2
+    RunSample       = 3
+    CollectSample   = 4
 
 class Result(Enum):
-    Unexecuted = 1
-    Success = 2
-    Fail = 3
-    Complete = 4
+    Unexecuted      = 1
+    Success         = 2
+    Fail            = 3
+    Complete        = 4

--- a/src/lasdi/gp.py
+++ b/src/lasdi/gp.py
@@ -1,80 +1,200 @@
-import numpy as np
-from sklearn.gaussian_process.kernels import ConstantKernel, Matern, RBF
-from sklearn.gaussian_process import GaussianProcessRegressor
+import  numpy                               as      np
+from    sklearn.gaussian_process.kernels    import  ConstantKernel, Matern, RBF
+from    sklearn.gaussian_process            import  GaussianProcessRegressor
 
-def fit_gps(X, Y):
 
-    '''
-    Trains each GP given the interpolation dataset.
-    X: (n_train, n_param) numpy 2d array
-    Y: (n_train, n_coef) numpy 2d array
+
+
+# -------------------------------------------------------------------------------------------------
+# Gaussian Process functions! 
+# -------------------------------------------------------------------------------------------------
+
+def fit_gps(X : np.ndarray, Y : np.ndarray) -> list[GaussianProcessRegressor]:
+    """
+    Trains a GP for each column of Y. If Y has shape N x k, then we train k GP regressors. In this 
+    case, we assume that X has shape N x M. Thus, the Input to the GP is in \mathbb{R}^M. For each
+    k, we train a GP where the i'th row of X is the input and the i,k component of Y is the
+    corresponding target. Thus, we return a list of k GP Regressor objects, the k'th one of which 
+    makes predictions for the k'th coefficient in the latent dynamics. 
+
     We assume each target coefficient is independent with each other.
-    gp_dictionnary is a dataset containing the trained GPs (as sklearn objects)
 
-    '''
 
-    n_coef = 1 if (Y.ndim == 1) else Y.shape[1]
+
+    -----------------------------------------------------------------------------------------------
+    Arguments
+    -----------------------------------------------------------------------------------------------
+
+    X: A 2d numpy array of shape (n_train, input_dim), where n_train is the number of training 
+    examples and input_dim is the number of components in each input (e.g., the number of 
+    parameters)
+
+    Y: A 2d numpy array of shape (n_train, n_coef), where n_train is the number of training 
+    examples and n_coef is the number of coefficients in the latent dynamics. 
+
+    
+
+    -----------------------------------------------------------------------------------------------
+    Returns
+    -----------------------------------------------------------------------------------------------
+
+    A list of trained GP regressor objects. If Y has k columns, then the returned list has k 
+    elements. It's i'th element holds a trained GP regressor object whose training inputs are the 
+    columns of X and whose corresponding target values are the elements of the i'th column of Y.
+    """
+
+    # Determine the number of components (columns) of Y. Since this is a regression task, we will
+    # perform a GP regression fit on each component (column) of Y.
+    n_coef : int = 1 if (Y.ndim == 1) else Y.shape[1]
+
+    # Transpose Y so that each row corresponds to a particular coefficient. This allows us to 
+    # iterate over the coefficients by iterating through the rows of Y.
     if (n_coef > 1):
         Y = Y.T
 
+    # Sklearn requires X to be a 2D array... so make sure this holds.
     if X.ndim == 1:
         X = X.reshape(-1, 1)
 
-    gp_dictionnary = []
+    # Initialize a list to hold the trained GP objects.
+    gp_list : list[GaussianProcessRegressor] = []
 
+    # Cycle through the rows of Y (which we transposed... so this just cycles through the 
+    # coefficients)
     for yk in Y:
+        # Make the kernel.
         # kernel = ConstantKernel() * Matern(length_scale_bounds = (0.01, 1e5), nu = 1.5)
-        kernel = ConstantKernel() * RBF(length_scale_bounds = (0.1, 1e5))
+        kernel  = ConstantKernel() * RBF(length_scale_bounds = (0.1, 1e5))
 
-        gp = GaussianProcessRegressor(kernel = kernel, n_restarts_optimizer = 10, random_state = 1)
+        # Initialize the GP object.
+        gp      = GaussianProcessRegressor(kernel = kernel, n_restarts_optimizer = 10, random_state = 1)
+
+        # Fit it to the data (train), then add it to the list of trained GPs
         gp.fit(X, yk)
+        gp_list += [gp]
 
-        gp_dictionnary += [gp]
+    # All done!
+    return gp_list
 
-    return gp_dictionnary
 
-def eval_gp(gp_dictionnary, param_grid):
 
-    '''
-
+def eval_gp(gp_list : list[GaussianProcessRegressor], param_grid : np.ndarray) -> tuple:
+    """
     Computes the GPs predictive mean and standard deviation for points of the parameter space grid
 
-    '''
 
-    n_coef = len(gp_dictionnary)
+    
+    -----------------------------------------------------------------------------------------------
+    Arguments
+    -----------------------------------------------------------------------------------------------
+
+    gp_list: a list of trained GP regressor objects. The number of elements in this list should 
+    match the number of columns in param_grid. The i'th element of this list is a GP regressor 
+    object that predicts the i'th coefficient. 
+    
+    param_grid: A 2d numpy.ndarray object of shape (number of parameter combination, number of 
+    parameters). The i,j element of this array specifies the value of the j'th parameter in the 
+    i'th combination of parameters. We use this as the testing set for the GP evaluation.
+
+
+    
+    -----------------------------------------------------------------------------------------------
+    Returns
+    -----------------------------------------------------------------------------------------------  
+
+    A two element tuple. Both are 2d numpy arrays of shape (number of parameter combinations, 
+    number of coefficients). The two arrays hold the predicted means and std's for each parameter
+    at each training example, respectively. 
+    
+    Thus, the i,j element of the first return variable holds the predicted mean of the j'th 
+    coefficient in the latent dynamics at the i'th training example. Likewise, the i,j element of 
+    the second return variable holds the standard deviation in the predicted distribution for the 
+    j'th coefficient in the latent dynamics at the i'th combination of parameter values.
+    """
+
+    # Fetch the numbers coefficients. Since there is one GP Regressor per SINDy coefficient, this 
+    # just the length of the gp_list.
+    n_coef : int = len(gp_list)
+
+    # Fetch the number of parameters, make sure the grid is 2D. 
     if (param_grid.ndim == 1):
         param_grid = param_grid.reshape(1, -1)
     n_points = param_grid.shape[0]
 
+    # Initialize arrays to hold the mean, STD.
     pred_mean, pred_std = np.zeros([n_points, n_coef]), np.zeros([n_points, n_coef])
-    for k, gp in enumerate(gp_dictionnary):
+
+    # Cycle through the GPs (one for each coefficient in the SINDy coefficients!).
+    for k, gp in enumerate(gp_list):
+        # Make predictions using the parameters in the param_grid.
         pred_mean[:, k], pred_std[:, k] = gp.predict(param_grid, return_std = True)
 
+    # All done!
     return pred_mean, pred_std
 
-def sample_coefs(gp_dictionnary, param, n_samples):
 
-    '''
 
-    Generates sample sets of ODEs for one given parameter.
-    coef_samples is a list of length n_samples, where each terms is a matrix of SINDy coefficients sampled from the GP predictive
-    distributions
+def sample_coefs(   gp_list     : list[GaussianProcessRegressor], 
+                    param       : np.ndarray, 
+                    n_samples   : int):
+    """
+    Generates sets of ODE (SINDy) coefficients sampled from the predictive distribution for those 
+    coefficients at the specified parameter value (parma). Specifically, for the k'th SINDy 
+    coefficient, we draw n_samples samples of the predictive distribution for the k'th coefficient
+    when param is the parameter. 
+    
+    
 
-    '''
+    -----------------------------------------------------------------------------------------------
+    Arguments
+    -----------------------------------------------------------------------------------------------
 
-    n_coef = len(gp_dictionnary)
-    coef_samples = np.zeros([n_samples, n_coef])
+    gp_list: a list of trained GP regressor objects. The number of elements in this list should 
+    match the number of columns in param_grid. The i'th element of this list is a GP regressor 
+    object that predicts the i'th coefficient. 
 
+    param: A combination of parameter values. i.e., a single test example. We evaluate each GP in 
+    the gp_list at this parameter value (getting a prediction for each coefficient).
+
+    n_samples: Number of samples of the predicted latent dynamics used to build ensemble of fom 
+    predictions. N_s in the paper. 
+
+    
+
+    -----------------------------------------------------------------------------------------------
+    Returns
+    -----------------------------------------------------------------------------------------------
+
+    A 2d numpy ndarray object called coef_samples. It has shape (n_samples, n_coef), where n_coef 
+    is the number of coefficients (length of gp_list). The i,j element of this list is the i'th 
+    sample of the j'th SINDy coefficient.
+    """
+
+    # Fetch the number of coefficients (since there is one GP Regressor per coefficient, this is
+    # just the length of the gp_list).
+    n_coef          : int           = len(gp_list)
+
+    # Initialize an array to hold the coefficient samples.
+    coef_samples    : np.ndarray    = np.zeros([n_samples, n_coef])
+
+    # Make sure param is a 2d array with one row, we need this when evaluating the GP Regressor
+    # object.
     if param.ndim == 1:
         param = param.reshape(1, -1)
-    n_points = param.shape[0]
+    
+    # Make sure we only have a single sample.
+    n_points : int = param.shape[0]
     assert(n_points == 1)
 
-    pred_mean, pred_std = eval_gp(gp_dictionnary, param)
+    # Evaluate the predicted mean and std at the parameter value.
+    pred_mean, pred_std = eval_gp(gp_list, param)
     pred_mean, pred_std = pred_mean[0], pred_std[0]
 
+    # Cycle through the samples and coefficients. For each sample of the k'th coefficient, we draw
+    # a sample from the normal distribution with mean pred_mean[k] and std pred_std[k].
     for s in range(n_samples):
         for k in range(n_coef):
             coef_samples[s, k] = np.random.normal(pred_mean[k], pred_std[k])
 
+    # All done!
     return coef_samples

--- a/src/lasdi/gplasdi.py
+++ b/src/lasdi/gplasdi.py
@@ -138,7 +138,7 @@ class BayesianGLaSDI:
         else:
             self.device = 'cpu'
 
-        self.best_loss = np.Inf
+        self.best_loss = np.inf
         self.best_coefs = None
         self.restart_iter = 0
 

--- a/src/lasdi/gplasdi.py
+++ b/src/lasdi/gplasdi.py
@@ -92,7 +92,7 @@ class BayesianGLaSDI:
     X_train = torch.Tensor([])
     X_test = torch.Tensor([])
 
-    def __init__(self, physics, autoencoder, latent_dynamics, config):
+    def __init__(self, physics, autoencoder, latent_dynamics, param_space, config):
 
         '''
 
@@ -106,7 +106,7 @@ class BayesianGLaSDI:
         self.autoencoder = autoencoder
         self.latent_dynamics = latent_dynamics
         self.physics = physics
-        self.param_space = physics.param_space
+        self.param_space = param_space
         self.timer = Timer()
 
         self.n_samples = config['n_samples']

--- a/src/lasdi/gplasdi.py
+++ b/src/lasdi/gplasdi.py
@@ -257,7 +257,7 @@ class BayesianGLaSDI:
 
         m_index = get_fom_max_std(ae, Zis)
 
-        new_sample = ps.test_space[m_index, :]
+        new_sample = ps.test_space[m_index, :].reshape(1, -1)
         print('New param: ' + str(np.round(new_sample, 4)) + '\n')
 
         self.timer.end("new_sample")

--- a/src/lasdi/inputs.py
+++ b/src/lasdi/inputs.py
@@ -47,7 +47,7 @@ def getDictFromList(list_, inputDict):
     '''
         get a dict with {key: val} from a list of dicts
         NOTE: it returns only the first item in the list,
-            even if the list has more than one dict with {key: val}.
+        even if the list has more than one dict with {key: val}.
     '''
     dict_ = None
     for item in list_:

--- a/src/lasdi/inputs.py
+++ b/src/lasdi/inputs.py
@@ -1,67 +1,159 @@
+# -------------------------------------------------------------------------------------------------
+# Imports
+# -------------------------------------------------------------------------------------------------
+
 from warnings import warn
 
-verbose = False
+verbose : bool = False
+
+
+# -------------------------------------------------------------------------------------------------
+# Input Parser class
+# -------------------------------------------------------------------------------------------------
 
 class InputParser:
-    dict_ = None
-    name = ""
+    """
+    A InputParser objects acts as a wrapper around a dictionary of settings. Thus, each setting is 
+    a key and the corresponding value is the setting's value. Because one setting may itself be 
+    a dictionary (we often group settings; each group has a name but several constituent settings),
+    the underlying dictionary is structured as a sequence of nested dictionaries. This class allows 
+    the user to select a specific setting from that structure by specifying (via a list of strings) 
+    where in that nested structure the desired setting lives. 
+    """
+    dict_   : dict  = None
+    name    : str   = ""
 
-    def __init__(self, dict, name = ""):
+
+
+    def __init__(self, dict : dict, name : str = "") -> None:
+        """"
+        Initializes an InputParser object by setting the underlying dictionary of settings as an 
+        attribute.
+
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+        
+        dict: The dictionary of settings. To avoid the risk of the user accidentally changing one 
+        of the settings after wrapping it, we store a deep copy of dict in self.
+        """
+
+        # A shallow copy could cause issues if the user changes dict's keys/values after 
+        # initializing this object. We store a deep copy to avoid this risk.
         from copy import deepcopy
         self.dict_ = deepcopy(dict)
-        self.name = name
-        return
 
-    def getInput(self, keys, fallback=None, datatype=None):
+        self.name = name
+
+
+
+    def getInput(self, keys : list, fallback = None, datatype = None):
         '''
-            Find the value corresponding to the list of keys.
-            If the specified keys do not exist, use the fallback value.
-            If the fallback value does not exist, returns an error.
-            If the datatype is specified, enforce the output value has the right datatype.
+        A InputParser object acts as a wrapper around a dictionary of settings. That is, self.dict_
+        is structured as a nested family of dictionaries. Each setting corresponds to a key in 
+        self.dict_. The setting's value is the corresponding value in self.dict_. In many cases, 
+        a particular setting may be nested within others. That is, a setting's value may itself be
+        another dictionary housing various sub-settings. This function allows us to fetch a 
+        specific setting from this nested structure. 
+
+        Specifically, we specify a list of strings. keys[0] should be a key in self.dict_
+        If so, we set val = self.dict_[keys[0]]. If there are more keys, then val should be a 
+        dictionary and keys[1] should be a key in this dictionary. In this case, we replace val 
+        with val[key[1]] and so on. This continues until we have exhausted all keys. There is one  
+        important exception: 
+
+            If at some point in the process, there are more keys but val is not a dictionary, or if
+            there are more keys and val is a dictionary but the next key is not a key in that
+            dictionary, then we return the fallback value. If the fallback value does not exist, 
+            returns an error.
+        
+
+                       
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        keys: A list of keys we want to fetch from self.dict. keys[0] should be a key in self.dict_
+        If so, we set val = self.dict_[keys[0]]. If there are more keys, then val should be a 
+        dictionary and keys[1] should be a key in this dictionary. In this case, we replace val 
+        with val[key[1]] and so on. This continues until we have exhausted all keys.
+
+        fallback: A sort of default value. If at some point, val is not a dictionary (and there are
+        more keys) or val is a dictionary but the next key is not a valid key in that dictionary, 
+        then we return the fallback value.
+
+        datatype: If not None, then we require that the final val has this datatype. If the final 
+        val does not have the desired datatype, we raise an exception.
+
+        
+
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        The final val value as outlined by the process described above.
         '''
+
+        # Concatenate the keys together. This is for debugging purposes.
         keyString = ""
         for key_ in keys:
             keyString += key_ + "/"
 
+        # Begin by initializing val to self.dict_
         val = self.dict_
+
+        # Cycle through the keys
         for key in keys:
+
+            # Check if the current key is a key in val (this assumes val is a dictionary). If so, 
+            # update val. Otherwise, return the fallback (if it is present) or raise an exception.
             if key in val:
                 val = val[key]
             elif (fallback != None):
                 return fallback
             else:
                 raise RuntimeError("%s does not exist in the input dictionary %s!" % (keyString, self.name))
-
+        
+        # Check if the fallback and final val have the same type.
         if (fallback != None):
             if (type(val) != type(fallback)):
                 warn("%s does not match the type with the fallback value %s!" % (str(type(val)), str(type(fallback))))
-                
+        
+        # Check thast the final val matches the desired datatype
         if (datatype != None):
             if (type(val) != datatype):
                 raise RuntimeError("%s does not match the specified datatype %s!" % (str(type(val)), str(datatype)))
         else:
             if verbose: warn("InputParser Warning: datatype is not checked.\n key: %s\n value type: %s" % (keys, type(val)))
+        
+        # All done!
         return val
 
-def getDictFromList(list_, inputDict):
-    '''
-        get a dict with {key: val} from a list of dicts
-        NOTE: it returns only the first item in the list,
-        even if the list has more than one dict with {key: val}.
-    '''
-    dict_ = None
-    for item in list_:
-        isDict = True
-        for key, val in inputDict.items():
-            if key not in item:
-                isDict = False
-                break
-            if (item[key] != val):
-                isDict = False
-                break
-        if (isDict):
-            dict_ = item
-            break
-    if (dict_ == None):
-        raise RuntimeError('Given list does not have a dict with {%s: %s}!' % (key, val))
-    return dict_
+
+
+# -------------------------------------------------------------------------------------------------
+# Unused: getDictFromList function
+# -------------------------------------------------------------------------------------------------
+
+#def getDictFromList(list_, inputDict):
+#    '''
+#        get a dict with {key: val} from a list of dicts
+#        NOTE: it returns only the first item in the list,
+#            even if the list has more than one dict with {key: val}.
+#    '''
+#    dict_ = None
+#    for item in list_:
+#        isDict = True
+#        for key, val in inputDict.items():
+#            if key not in item:
+#                isDict = False
+#                break
+#            if (item[key] != val):
+#                isDict = False
+#                break
+#        if (isDict):
+#            dict_ = item
+#            break
+#    if (dict_ == None):
+#        raise RuntimeError('Given list does not have a dict with {%s: %s}!' % (key, val))
+#    return dict_

--- a/src/lasdi/latent_dynamics/__init__.py
+++ b/src/lasdi/latent_dynamics/__init__.py
@@ -57,3 +57,10 @@ class LatentDynamics:
         param_dict = {'dim': self.dim, 'ncoefs': self.ncoefs}
         return param_dict
     
+    # SINDy does not need to load parameters.
+    # Other latent dynamics might need to.
+    def load(self, dict_):
+        assert(self.dim == dict_['dim'])
+        assert(self.ncoefs == dict_['ncoefs'])
+        return
+    

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -15,7 +15,6 @@ def initial_condition_latent(param_grid, physics, autoencoder):
     sol_shape = [1, 1] + physics.qgrid_size
 
     for i in range(n_param):
-        # TODO(kevin): generalize parameter class.
         u0 = physics.initial_condition(param_grid[i])
         u0 = u0.reshape(sol_shape)
         u0 = torch.Tensor(u0)

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -66,6 +66,7 @@ class MultiLayerPerceptron(torch.nn.Module):
         for k in range(self.n_layers-1):
             self.fcs += [torch.nn.Linear(layer_sizes[k], layer_sizes[k + 1])]
         self.fcs = torch.nn.ModuleList(self.fcs)
+        self.init_weight()
 
         # Reshape input or output layer
         assert((reshape_index is None) or (reshape_index in [0, -1]))

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -175,3 +175,11 @@ class Autoencoder(torch.nn.Module):
         x = x.squeeze(1)  # Remove sequence dimension
         
         return x
+    
+    def export(self):
+        dict_ = {'autoencoder_param': self.cpu().state_dict()}
+        return dict_
+    
+    def load(self, dict_):
+        self.load_state_dict(dict_['autoencoder_param'])
+        return

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -1,6 +1,32 @@
 import torch
 import numpy as np
 
+# activation dict
+act_dict = {'ELU': torch.nn.ELU,
+            'hardshrink': torch.nn.Hardshrink,
+            'hardsigmoid': torch.nn.Hardsigmoid,
+            'hardtanh': torch.nn.Hardtanh,
+            'hardswish': torch.nn.Hardswish,
+            'leakyReLU': torch.nn.LeakyReLU,
+            'logsigmoid': torch.nn.LogSigmoid,
+            'multihead': torch.nn.MultiheadAttention,
+            'PReLU': torch.nn.PReLU,
+            'ReLU': torch.nn.ReLU,
+            'ReLU6': torch.nn.ReLU6,
+            'RReLU': torch.nn.RReLU,
+            'SELU': torch.nn.SELU,
+            'CELU': torch.nn.CELU,
+            'GELU': torch.nn.GELU,
+            'sigmoid': torch.nn.Sigmoid,
+            'SiLU': torch.nn.SiLU,
+            'mish': torch.nn.Mish,
+            'softplus': torch.nn.Softplus,
+            'softshrink': torch.nn.Softshrink,
+            'tanh': torch.nn.Tanh,
+            'tanhshrink': torch.nn.Tanhshrink,
+            'threshold': torch.nn.Threshold,
+            }
+
 def initial_condition_latent(param_grid, physics, autoencoder):
 
     '''
@@ -23,39 +49,88 @@ def initial_condition_latent(param_grid, physics, autoencoder):
         Z0.append(z0)
 
     return Z0
-    
-class Autoencoder(torch.nn.Module):
-    # set by physics.qgrid_size
-    qgrid_size = []
-    # prod(qgrid_size)
-    space_dim = -1
-    n_z = -1
 
-    # activation dict
-    act_dict = {'ELU': torch.nn.ELU,
-                'hardshrink': torch.nn.Hardshrink,
-                'hardsigmoid': torch.nn.Hardsigmoid,
-                'hardtanh': torch.nn.Hardtanh,
-                'hardswish': torch.nn.Hardswish,
-                'leakyReLU': torch.nn.LeakyReLU,
-                'logsigmoid': torch.nn.LogSigmoid,
-                'multihead': torch.nn.MultiheadAttention,
-                'PReLU': torch.nn.PReLU,
-                'ReLU': torch.nn.ReLU,
-                'ReLU6': torch.nn.ReLU6,
-                'RReLU': torch.nn.RReLU,
-                'SELU': torch.nn.SELU,
-                'CELU': torch.nn.CELU,
-                'GELU': torch.nn.GELU,
-                'sigmoid': torch.nn.Sigmoid,
-                'SiLU': torch.nn.SiLU,
-                'mish': torch.nn.Mish,
-                'softplus': torch.nn.Softplus,
-                'softshrink': torch.nn.Softshrink,
-                'tanh': torch.nn.Tanh,
-                'tanhshrink': torch.nn.Tanhshrink,
-                'threshold': torch.nn.Threshold,
-                }
+class MultiLayerPerceptron(torch.nn.Module):
+
+    def __init__(self, layer_sizes,
+                 act_type='sigmoid', reshape_index=None, reshape_shape=None,
+                 threshold=0.1, value=0.0, num_heads=1):
+        super(MultiLayerPerceptron, self).__init__()
+
+        # including input, hidden, output layers
+        self.n_layers = len(layer_sizes)
+        self.layer_sizes = layer_sizes
+
+        # Linear features between layers
+        self.fcs = []
+        for k in range(self.n_layers-1):
+            self.fcs += [torch.nn.Linear(layer_sizes[k], layer_sizes[k + 1])]
+        self.fcs = torch.nn.ModuleList(self.fcs)
+
+        # Reshape input or output layer
+        assert((reshape_index is None) or (reshape_index in [0, -1]))
+        assert((reshape_shape is None) or (np.prod(reshape_shape) == layer_sizes[reshape_index]))
+        self.reshape_index = reshape_index
+        self.reshape_shape = reshape_shape
+
+        # Initalize activation function
+        self.act_type = act_type
+        self.use_multihead = False
+        if act_type == "threshold":
+            self.act = act_dict[act_type](threshold, value)
+
+        elif act_type == "multihead":
+            self.use_multihead = True
+            if (self.n_layers > 3): # if you have more than one hidden layer
+                self.act = []
+                for i in range(self.n_layers-2):
+                    self.act += [act_dict[act_type](layer_sizes[i+1], num_heads)]
+            else:
+                self.act = [torch.nn.Identity()]  # No additional activation
+            self.act = torch.nn.ModuleList(self.fcs)
+
+        #all other activation functions initialized here
+        else:
+            self.act = act_dict[act_type]()
+        return
+    
+    def forward(self, x):
+        if (self.reshape_index == 0):
+            # make sure the input has a proper shape
+            assert(list(x.shape[-len(self.reshape_shape):]) == self.reshape_shape)
+            # we use torch.Tensor.view instead of torch.Tensor.reshape,
+            # in order to avoid data copying.
+            x = x.view(list(x.shape[:-len(self.reshape_shape)]) + [self.layer_sizes[self.reshape_index]])
+
+        for i in range(self.n_layers-2):
+            x = self.fcs[i](x) # apply linear layer
+            if (self.use_multihead):
+                x = self.apply_attention(self, x, i)
+            else:
+                x = self.act(x)
+
+        x = self.fcs[-1](x)
+
+        if (self.reshape_index == -1):
+            # we use torch.Tensor.view instead of torch.Tensor.reshape,
+            # in order to avoid data copying.
+            x = x.view(list(x.shape[:-1]) + self.reshape_shape)
+
+        return x
+    
+    def apply_attention(self, x, act_idx):
+        x = x.unsqueeze(1)  # Add sequence dimension for attention
+        x, _ = self.act[act_idx](x, x, x) # apply attention
+        x = x.squeeze(1)  # Remove sequence dimension
+        return x
+    
+    def init_weight(self):
+        # TODO(kevin): support other initializations?
+        for fc in self.fcs:
+            torch.nn.init.xavier_uniform_(fc.weight)
+        return
+
+class Autoencoder(torch.nn.Module):
 
     def __init__(self, physics, config):
         super(Autoencoder, self).__init__()
@@ -66,113 +141,28 @@ class Autoencoder(torch.nn.Module):
         n_z = config['latent_dimension']
         self.n_z = n_z
 
-        n_layers = len(hidden_units)
-        self.n_layers = n_layers
-
-        fc1_e = torch.nn.Linear(self.space_dim, hidden_units[0])
-        torch.nn.init.xavier_uniform_(fc1_e.weight)
-        self.fc1_e = fc1_e
-
-        if n_layers > 1:
-            for i in range(n_layers - 1):
-                fc_e = torch.nn.Linear(hidden_units[i], hidden_units[i + 1])
-                torch.nn.init.xavier_uniform_(fc_e.weight)
-                setattr(self, 'fc' + str(i + 2) + '_e', fc_e)
-
-        fc_e = torch.nn.Linear(hidden_units[-1], n_z)
-        torch.nn.init.xavier_uniform_(fc_e.weight)
-        setattr(self, 'fc' + str(n_layers + 1) + '_e', fc_e)
-
+        layer_sizes = [self.space_dim] + hidden_units + [n_z]
+        #grab relevant initialization values from config
         act_type = config['activation'] if 'activation' in config else 'sigmoid'
-        if act_type == "threshold":
-            #grab relevant initialization values from config
-            threshold = config["threshold"] if "threshold" in config else 0.1
-            value = config["value"] if "value" in config else 0.0
-            self.g_e = self.act_dict[act_type](threshold, value)
+        threshold = config["threshold"] if "threshold" in config else 0.1
+        value = config["value"] if "value" in config else 0.0
+        num_heads = config['num_heads'] if 'num_heads' in config else 1
 
-        elif act_type == "multihead":
-            #grab relevant initialization values from config
-            num_heads = config['num_heads'] if 'num_heads' in config else 1
-            if n_layers > 1:
-                for i in range(n_layers):
-                    setattr(self, 'a' + str(i + 1), self.act_dict[act_type](hidden_units[i], num_heads))
-            self.g_e = torch.nn.Identity()  # No additional activation
+        self.encoder = MultiLayerPerceptron(layer_sizes, act_type,
+                                            reshape_index=0, reshape_shape=self.qgrid_size,
+                                            threshold=threshold, value=value, num_heads=num_heads)
+        
+        self.decoder = MultiLayerPerceptron(layer_sizes[::-1], act_type,
+                                            reshape_index=-1, reshape_shape=self.qgrid_size,
+                                            threshold=threshold, value=value, num_heads=num_heads)
 
-        #all other activation functions initialized here
-        else:
-            self.g_e = self.act_dict[act_type]()
-
-        fc1_d = torch.nn.Linear(n_z, hidden_units[-1])
-        torch.nn.init.xavier_uniform_(fc1_d.weight)
-        self.fc1_d = fc1_d
-
-        if n_layers > 1:
-            for i in range(n_layers - 1, 0, -1):
-                fc_d = torch.nn.Linear(hidden_units[i], hidden_units[i - 1])
-                torch.nn.init.xavier_uniform_(fc_d.weight)
-                setattr(self, 'fc' + str(n_layers - i + 1) + '_d', fc_d)
-
-        fc_d = torch.nn.Linear(hidden_units[0], self.space_dim)
-        torch.nn.init.xavier_uniform_(fc_d.weight)
-        setattr(self, 'fc' + str(n_layers + 1) + '_d', fc_d)
-
-
-
-    def encoder(self, x):
-        # make sure the input has a proper shape
-        assert(list(x.shape[-len(self.qgrid_size):]) == self.qgrid_size)
-        # we use torch.Tensor.view instead of torch.Tensor.reshape,
-        # in order to avoid data copying.
-        x = x.view(list(x.shape[:-len(self.qgrid_size)]) + [self.space_dim])
-
-        for i in range(1, self.n_layers + 1):
-            fc = getattr(self, 'fc' + str(i) + '_e')
-            x = fc(x) # apply linear layer
-            if hasattr(self, 'a1'): # test if there is at least one attention layer
-                x = self.apply_attention(self, x, i)
-                
-            x = self.g_e(x) # apply activation function
-
-        fc = getattr(self, 'fc' + str(self.n_layers + 1) + '_e')
-        x = fc(x)
-
-        return x
-
-
-    def decoder(self, x):
-
-        for i in range(1, self.n_layers + 1):
-            fc = getattr(self, 'fc' + str(i) + '_d')
-            x = fc(x) # apply linear layer
-            if hasattr(self, 'a1'): # test if there is at least one attention layer
-                x = self.apply_attention(self, x, self.n_layers - i)
-
-            x = self.g_e(x) # apply activation function
-
-        fc = getattr(self, 'fc' + str(self.n_layers + 1) + '_d')
-        x = fc(x)
-
-        # we use torch.Tensor.view instead of torch.Tensor.reshape,
-        # in order to avoid data copying.
-        x = x.view(list(x.shape[:-1]) + self.qgrid_size)
-
-        return x
-
+        return
 
     def forward(self, x):
 
         x = self.encoder(x)
         x = self.decoder(x)
 
-        return x
-
-
-    def apply_attention(self, x, layer):
-        x = x.unsqueeze(1)  # Add sequence dimension for attention
-        a = getattr(self, 'a' + str(layer))
-        x, _ = a(x, x, x) # apply attention
-        x = x.squeeze(1)  # Remove sequence dimension
-        
         return x
     
     def export(self):

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -53,7 +53,8 @@ def initial_condition_latent(param_grid     : np.ndarray,
     -----------------------------------------------------------------------------------------------
 
     param_grid: A 2d numpy.ndarray object of shape (number of parameter combination) x (number of 
-    parameters).
+    parameters). The i,j element of this array holds the value of the j'th parameter in the i'th 
+    combination of parameters.
 
     physics: A "Physics" object that stores the datasets for each parameter combination. 
 

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -1,146 +1,323 @@
-import torch
-import numpy as np
+# -------------------------------------------------------------------------------------------------
+# Imports and setup
+# -------------------------------------------------------------------------------------------------
+
+import  torch
+import  numpy       as      np
+
+from   .physics     import  Physics
 
 # activation dict
-act_dict = {'ELU': torch.nn.ELU,
-            'hardshrink': torch.nn.Hardshrink,
-            'hardsigmoid': torch.nn.Hardsigmoid,
-            'hardtanh': torch.nn.Hardtanh,
-            'hardswish': torch.nn.Hardswish,
-            'leakyReLU': torch.nn.LeakyReLU,
-            'logsigmoid': torch.nn.LogSigmoid,
-            'multihead': torch.nn.MultiheadAttention,
-            'PReLU': torch.nn.PReLU,
-            'ReLU': torch.nn.ReLU,
-            'ReLU6': torch.nn.ReLU6,
-            'RReLU': torch.nn.RReLU,
-            'SELU': torch.nn.SELU,
-            'CELU': torch.nn.CELU,
-            'GELU': torch.nn.GELU,
-            'sigmoid': torch.nn.Sigmoid,
-            'SiLU': torch.nn.SiLU,
-            'mish': torch.nn.Mish,
-            'softplus': torch.nn.Softplus,
-            'softshrink': torch.nn.Softshrink,
-            'tanh': torch.nn.Tanh,
-            'tanhshrink': torch.nn.Tanhshrink,
-            'threshold': torch.nn.Threshold,
-            }
+act_dict = {'ELU'           : torch.nn.ELU,
+            'hardshrink'    : torch.nn.Hardshrink,
+            'hardsigmoid'   : torch.nn.Hardsigmoid,
+            'hardtanh'      : torch.nn.Hardtanh,
+            'hardswish'     : torch.nn.Hardswish,
+            'leakyReLU'     : torch.nn.LeakyReLU,
+            'logsigmoid'    : torch.nn.LogSigmoid,
+            'PReLU'         : torch.nn.PReLU,
+            'ReLU'          : torch.nn.ReLU,
+            'ReLU6'         : torch.nn.ReLU6,
+            'RReLU'         : torch.nn.RReLU,
+            'SELU'          : torch.nn.SELU,
+            'CELU'          : torch.nn.CELU,
+            'GELU'          : torch.nn.GELU,
+            'sigmoid'       : torch.nn.Sigmoid,
+            'SiLU'          : torch.nn.SiLU,
+            'mish'          : torch.nn.Mish,
+            'softplus'      : torch.nn.Softplus,
+            'softshrink'    : torch.nn.Softshrink,
+            'tanh'          : torch.nn.Tanh,
+            'tanhshrink'    : torch.nn.Tanhshrink,
+            'threshold'     : torch.nn.Threshold,}
 
-def initial_condition_latent(param_grid, physics, autoencoder):
 
-    '''
 
-    Outputs the initial condition in the latent space: Z0 = encoder(U0)
+# -------------------------------------------------------------------------------------------------
+# initial_conditions_latent function
+# -------------------------------------------------------------------------------------------------
 
-    '''
+def initial_condition_latent(param_grid     : np.ndarray, 
+                             physics        : Physics, 
+                             autoencoder    : torch.nn.Module) -> list[np.ndarray]:
+    """
+    This function maps a set of initial conditions for the fom to initial conditions for the 
+    latent space dynamics. Specifically, we take in a set of possible parameter values. For each 
+    set of parameter values, we recover the fom IC (from physics), then map this fom IC to a 
+    latent space IC (by encoding it using the autoencoder). We do this for each parameter 
+    combination and then return a list housing the latent space ICs.
 
-    n_param = param_grid.shape[0]
-    Z0 = []
+    
+    -----------------------------------------------------------------------------------------------
+    Arguments
+    -----------------------------------------------------------------------------------------------
 
-    sol_shape = [1, 1] + physics.qgrid_size
+    param_grid: A 2d numpy.ndarray object of shape (number of parameter combination) x (number of 
+    parameters).
 
+    physics: A "Physics" object that stores the datasets for each parameter combination. 
+
+    autoencoder: The actual autoencoder object that we use to map the ICs into the latent space.
+
+
+    -----------------------------------------------------------------------------------------------
+    Returns
+    -----------------------------------------------------------------------------------------------
+    
+    A list of numpy ndarray objects whose i'th element holds the latent space initial condition 
+    for the i'th set of parameters in the param_grid. That is, if we let U0_i denote the fom IC for 
+    the i'th set of parameters, then the i'th element of the returned list is Z0_i = encoder(U0_i).
+    """
+
+    # Figure out how many parameters we are testing at. 
+    n_param     : int               = param_grid.shape[0]
+    Z0          : list[np.ndarray]  = []
+    sol_shape   : list[int]         = [1, 1] + physics.qgrid_size
+    
+    # Cycle through the parameters.
     for i in range(n_param):
-        u0 = physics.initial_condition(param_grid[i])
+        # TODO(kevin): generalize parameter class.
+
+        # Fetch the IC for the i'th set of parameters. Then map it to a tensor.
+        u0 : np.ndarray = physics.initial_condition(param_grid[i])
         u0 = u0.reshape(sol_shape)
         u0 = torch.Tensor(u0)
+
+        # Encode the IC, then map the encoding to a numpy array.
         z0 = autoencoder.encoder(u0)
         z0 = z0[0, 0, :].detach().numpy()
+
+        # Append the new IC to the list of latent ICs
         Z0.append(z0)
 
+    # Return the list of latent ICs.
     return Z0
 
+
+
+# -------------------------------------------------------------------------------------------------
+# MLP class
+# -------------------------------------------------------------------------------------------------
+
 class MultiLayerPerceptron(torch.nn.Module):
+    def __init__(   self, 
+                    layer_sizes     : list[int],
+                    act_type        : str           = 'sigmoid',
+                    reshape_index   : int           = None, 
+                    reshape_shape   : tuple[int]    = None,
+                    threshold       : float         = 0.1, 
+                    value           : float         = 0.0) -> None:
+        """
+        This class defines a standard multi-layer network network.
 
-    def __init__(self, layer_sizes,
-                 act_type='sigmoid', reshape_index=None, reshape_shape=None,
-                 threshold=0.1, value=0.0, num_heads=1):
-        super(MultiLayerPerceptron, self).__init__()
 
-        # including input, hidden, output layers
-        self.n_layers = len(layer_sizes)
-        self.layer_sizes = layer_sizes
 
-        # Linear features between layers
-        self.fcs = []
-        for k in range(self.n_layers-1):
-            self.fcs += [torch.nn.Linear(layer_sizes[k], layer_sizes[k + 1])]
-        self.fcs = torch.nn.ModuleList(self.fcs)
-        self.init_weight()
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
 
-        # Reshape input or output layer
+        layer_sizes: A list of integers specifying the widths of the layers (including the 
+        dimensionality of the domain of each layer, as well as the co-domain of the final layer).
+        Suppose this list has N elements. Then the network will have N - 1 layers. The i'th layer 
+        maps from \mathbb{R}^{layer_sizes[i]} to \mathbb{R}^{layers_sizes[i]}. Thus, the i'th 
+        element of this list represents the domain of the i'th layer AND the co-domain of the 
+        i-1'th layer.
+
+        act_type: A string specifying which activation function we want to use at the end of each 
+        layer (except the final one). We use the same activation for each layer. 
+
+        reshape_index: This argument specifies if we should reshape the network's input or output 
+        (or neither). If the user specifies reshape_index, then it must be either 0 or -1. Further, 
+        in this case, they must also specify reshape_shape (you need to specify both together). If
+        it is 0, then reshape_shape specifies how we reshape the input before passing it through 
+        the network (the input to the first layer). If reshape_index is -1, then reshape_shape 
+        specifies how we reshape the network output before returning it (the output to the last 
+        layer). 
+
+        reshape_shape: These are lists of k integers specifying the final k dimensions of the shape
+        of the input to the first layer (if reshape_index == 0) or the output of the last layer 
+        (if reshape_index == -1). You must specify this argument if and only if you specify 
+        reshape_index. 
+
+        threshold: You should only specify this argument if you are using the "Threshold" 
+        activation type. In this case, it specifies the threshold value for that activation (if x
+        is the input and x > threshold, then the function returns x. Otherwise, it returns the 
+        value).
+
+        value: You should only specify this argument if you are using the "Threshold" activation
+        type. In this case, "value" specifies the value that the function returns if the input is
+        below the threshold. 
+
+
+
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+        
+        Nothing!
+        """
+
+        # Run checks.
+        # Make sure the reshape index is either 0 (input to 1st layer) or -1 (output of last 
+        # layer). Also make sure that that product of the dimensions in the reshape_shape match
+        # the input dimension for the 1st layer (if reshape_index == 0) or the output dimension of
+        # the last layer (if reshape_index == 1). 
+        # 
+        # Why do we need the later condition? Well, suppose that reshape_shape has a length of k. 
+        # If reshape_index == 0, then we squeeze the final k dimensions of the input and feed that 
+        # into the first layer. Thus, in this case, we need the last dimension of the squeezed 
+        # array to match the input domain of the first layer. On the other hand, reshape_index == -1 
+        # then we reshape the final dimension of the output to match the reshape_shape. Thus, in 
+        # both cases, we need the product of the components of reshape_shape to match a 
+        # corresponding element of layer_sizes.
         assert((reshape_index is None) or (reshape_index in [0, -1]))
         assert((reshape_shape is None) or (np.prod(reshape_shape) == layer_sizes[reshape_index]))
-        self.reshape_index = reshape_index
-        self.reshape_shape = reshape_shape
 
-        # Initalize activation function
-        self.act_type = act_type
-        self.use_multihead = False
+        super(MultiLayerPerceptron, self).__init__()
+
+        # Note that layer_sizes specifies the dimensionality of the domains and co-domains of each
+        # layer. Specifically, the i'th element specifies the input dimension of the i'th layer,
+        # while the final element specifies the dimensionality of the co-domain of the final layer.
+        # Thus, the number of layers is one less than the length of layer_sizes.
+        self.n_layers       : int                   = len(layer_sizes) - 1;
+        self.layer_sizes    : list[int]             = layer_sizes
+
+        # Set up the affine parts of the layers.
+        self.layers            : list[torch.nn.Module] = [];
+        for k in range(self.n_layers):
+            self.layers += [torch.nn.Linear(layer_sizes[k], layer_sizes[k + 1])]
+        self.layers = torch.nn.ModuleList(self.layers)
+
+        # Now, initialize the weight matrices and bias vectors in the affine portion of each layer.
+        self.init_weight()
+
+        # Reshape input to the 1st layer or output of the last layer.
+        self.reshape_index : int        = reshape_index
+        self.reshape_shape : list[int]  = reshape_shape
+
+        # Set up the activation function. Note that we need to handle the threshold activation type
+        # separately because it requires an extra set of parameters to initialize.
+        self.act_type   : str               = act_type
         if act_type == "threshold":
-            self.act = act_dict[act_type](threshold, value)
-
-        elif act_type == "multihead":
-            self.use_multihead = True
-            if (self.n_layers > 3): # if you have more than one hidden layer
-                self.act = []
-                for i in range(self.n_layers-2):
-                    self.act += [act_dict[act_type](layer_sizes[i+1], num_heads)]
-            else:
-                self.act = [torch.nn.Identity()]  # No additional activation
-            self.act = torch.nn.ModuleList(self.fcs)
-
-        #all other activation functions initialized here
+            self.act    : torch.nn.Module   = act_dict[act_type](threshold, value)
         else:
-            self.act = act_dict[act_type]()
+            self.act    : torch.nn.Module   = act_dict[act_type]()
+
+        # All done!
         return
     
-    def forward(self, x):
+
+
+    def forward(self, x : torch.Tensor) -> torch.Tensor:
+        """
+        This function defines the forward pass through self.
+
+
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        x: A tensor holding a batch of inputs. We pass this tensor through the network's layers 
+        and then return the result. If self.reshape_index == 0 and self.reshape_shape has k
+        elements, then the final k elements of x's shape must match self.reshape_shape. 
+
+
+        
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        The image of x under the network's layers. If self.reshape_index == -1 and 
+        self.reshape_shape has k elements, then we reshape the output so that the final k elements
+        of its shape match those of self.reshape_shape.
+        """
+
+        # If the reshape_index is 0, we need to reshape x before passing it through the first 
+        # layer.
         if (self.reshape_index == 0):
-            # make sure the input has a proper shape
+            # Make sure the input has a proper shape. There is a lot going on in this line; let's
+            # break it down. If reshape_index == 0, then we need to reshape the input, x, before
+            # passing it through the layers. Let's assume that reshape_shape has k elements. Then,
+            # we need to squeeze the final k dimensions of the input, x, so that the resulting 
+            # tensor has a final dimension size that matches the input dimension size for the first
+            # layer. The check below makes sure that the final k dimensions of the input, x, match
+            # the stored reshape_shape.
             assert(list(x.shape[-len(self.reshape_shape):]) == self.reshape_shape)
-            # we use torch.Tensor.view instead of torch.Tensor.reshape,
-            # in order to avoid data copying.
+            
+            # Now that we know the final k dimensions of x have the correct shape, let's squeeze 
+            # them into 1 dimension (so that we can pass the squeezed tensor through the first 
+            # layer). To do this, we reshape x by keeping all but the last k dimensions of x, and 
+            # replacing the last k with a single dimension whose size matches the dimensionality of
+            # the domain of the first layer. Note that we use torch.Tensor.view instead of 
+            # torch.Tensor.reshape in order to avoid data copying.
             x = x.view(list(x.shape[:-len(self.reshape_shape)]) + [self.layer_sizes[self.reshape_index]])
 
-        for i in range(self.n_layers-2):
-            x = self.fcs[i](x) # apply linear layer
-            if (self.use_multihead):
-                x = self.apply_attention(self, x, i)
-            else:
-                x = self.act(x)
+        # Pass x through the network layers (except for the final one, which has no activation 
+        # function).
+        for i in range(self.n_layers - 1):
+            x : torch.Tensor = self.layers[i](x)   # apply linear layer
+            x : torch.Tensor = self.act(x)      # apply activation
 
-        x = self.fcs[-1](x)
+        # Apply the final (output) layer.
+        x = self.layers[-1](x)
 
+        # If the reshape_index is -1, then we need to reshape the output before returning. 
         if (self.reshape_index == -1):
-            # we use torch.Tensor.view instead of torch.Tensor.reshape,
-            # in order to avoid data copying.
+            # In this case, we need to split the last dimension of x, the output of the final
+            # layer, to match the reshape_shape. This is precisely what the line below does. Note
+            # that we use torch.Tensor.view instead of torch.Tensor.reshape in order to avoid data 
+            # copying. 
             x = x.view(list(x.shape[:-1]) + self.reshape_shape)
 
+        # All done!
         return x
     
-    def apply_attention(self, x, act_idx):
-        x = x.unsqueeze(1)  # Add sequence dimension for attention
-        x, _ = self.act[act_idx](x, x, x) # apply attention
-        x = x.squeeze(1)  # Remove sequence dimension
-        return x
-    
-    def init_weight(self):
+
+
+    def init_weight(self) -> None:
+        """
+        This function initializes the weight matrices and bias vectors in self's layers.
+
+        
+
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        None!
+
+        
+
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        Nothing!
+        """
+
         # TODO(kevin): support other initializations?
-        for fc in self.fcs:
-            torch.nn.init.xavier_uniform_(fc.weight)
+        for layer in self.layers:
+            torch.nn.init.xavier_uniform_(layer.weight)
+            torch.nn.init.zeros_(layer.bias)
+        
+        # All done!
         return
 
-class Autoencoder(torch.nn.Module):
 
-    def __init__(self, physics, config):
+
+# -------------------------------------------------------------------------------------------------
+# Autoencoder class
+# -------------------------------------------------------------------------------------------------
+
+class Autoencoder(torch.nn.Module):
+    def __init__(self, physics : Physics, config : dict):
         super(Autoencoder, self).__init__()
 
-        self.qgrid_size = physics.qgrid_size
-        self.space_dim = np.prod(self.qgrid_size)
-        hidden_units = config['hidden_units']
-        n_z = config['latent_dimension']
-        self.n_z = n_z
+        self.qgrid_size                 = physics.qgrid_size;
+        self.space_dim  : np.ndarray    = np.prod(self.qgrid_size);
+        hidden_units    : int           = config['hidden_units'];
+        n_z             : int           = config['latent_dimension'];
+        self.n_z        : int           = n_z
 
         layer_sizes = [self.space_dim] + hidden_units + [n_z]
         #grab relevant initialization values from config
@@ -159,6 +336,8 @@ class Autoencoder(torch.nn.Module):
 
         return
 
+
+
     def forward(self, x):
 
         x = self.encoder(x)
@@ -166,10 +345,14 @@ class Autoencoder(torch.nn.Module):
 
         return x
     
+
+
     def export(self):
         dict_ = {'autoencoder_param': self.cpu().state_dict()}
         return dict_
     
+
+
     def load(self, dict_):
         self.load_state_dict(dict_['autoencoder_param'])
         return

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -386,7 +386,7 @@ class Autoencoder(torch.nn.Module):
                             value               = value);
 
         self.decoder = MultiLayerPerceptron(
-                            latent_sizes        = layer_sizes[::-1],    # Reverses the order of the the list.
+                            layer_sizes         = layer_sizes[::-1],    # Reverses the order of the the list.
                             act_type            = act_type,
                             reshape_index       = -1,               
                             reshape_shape       = self.qgrid_size,      # We need to reshape the network output to a fom frame.

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -25,8 +25,6 @@ class ParameterSpace:
     n_param = 0
     train_space = None
     test_space = None
-    n_test = 0
-    n_train = 0
     n_init = 0
     test_grid_sizes = []
     test_meshgrid = None
@@ -44,14 +42,18 @@ class ParameterSpace:
 
         self.train_space = self.createInitialTrainSpace(self.param_list)
         self.n_init = self.train_space.shape[0]
-        self.n_train = self.n_init
 
         test_space_type = parser.getInput(['test_space', 'type'], datatype=str)
         if (test_space_type == 'grid'):
             self.test_grid_sizes, self.test_meshgrid, self.test_space = self.createTestGridSpace(self.param_list)
-            self.n_test = self.test_space.shape[0]
 
         return
+    
+    def n_train(self):
+        return self.train_space.shape[0]
+    
+    def n_test(self):
+        return self.test_space.shape[0]
     
     def createInitialTrainSpace(self, param_list):
         paramRanges = []
@@ -129,7 +131,6 @@ class ParameterSpace:
         assert(self.train_space.shape[1] == param.size)
 
         self.train_space = np.vstack((self.train_space, param))
-        self.n_train = self.train_space.shape[0]
         return
     
     def export(self):
@@ -149,7 +150,4 @@ class ParameterSpace:
         assert(self.n_init == dict_['n_init'])
         assert(self.train_space.shape[1] == self.n_param)
         assert(self.test_space.shape[1] == self.n_param)
-
-        self.n_train = self.train_space.shape[0]
-        self.n_test = self.test_space.shape[0]
         return

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -1,83 +1,310 @@
-import numpy as np
-from .inputs import InputParser
+# -------------------------------------------------------------------------------------------------
+# Imports
+# -------------------------------------------------------------------------------------------------
 
-def get_1dspace_from_list(config):
-    Nx = len(config['list'])
-    paramRange = np.array(config['list'])
+import  numpy   as      np
+from    .inputs import  InputParser
+
+
+
+# -------------------------------------------------------------------------------------------------
+# Helper functions
+# -------------------------------------------------------------------------------------------------
+
+def get_1dspace_from_list(param_dict : dict) -> tuple[int, np.ndarray]:
+    """
+    This function generates the parameter range (set of possible parameter values) for a parameter 
+    that uses the list type test space. That is, "test_space_type" should be a key for the 
+    parameter dictionary and the corresponding value should be "list". The parameter dictionary 
+    should also have a "list" key whose value is a list of the possible parameter values.
+
+    We parse this list and turn it into a numpy ndarray.
+
+    
+    -----------------------------------------------------------------------------------------------
+    Arguments
+    -----------------------------------------------------------------------------------------------
+
+    param_dict: A dictionary specifying one of the parameters. We should fetch this from the 
+    configuration yaml file. It must have a "list" key whose corresponding value is a list of 
+    floats. 
+
+
+    -----------------------------------------------------------------------------------------------
+    Returns
+    -----------------------------------------------------------------------------------------------
+
+    Two arguments: Nx and paramRange. paramRange is a 1d numpy ndarray (whose ith value is the 
+    i'th element of param_dict["list"]). Nx is the length of paramRange. 
+    """
+
+    # In this case, the parameter dictionary should have a "list" attribute which should list the 
+    # parameter values we want to test. Fetch it (it's length is Nx) and use it to generate an
+    # array of possible values.
+    Nx          : int           = len(param_dict['list'])
+    paramRange  : np.ndarray    = np.array(param_dict['list'])
+
+    # All done!
     return Nx, paramRange
 
-def create_uniform_1dspace(config):
-    Nx = config['sample_size']
-    minval = config['min']
-    maxval = config['max']
-    if (config['log_scale']):
-        paramRange = np.exp(np.linspace(np.log(minval), np.log(maxval), Nx))
+
+
+def create_uniform_1dspace(param_dict : dict) -> tuple[int, np.ndarray]:
+    """
+    This function generates the parameter range (set of possible parameter values) for a parameter 
+    that uses the uniform type test space. That is, "test_space_type" should be a key for the 
+    parameter dictionary and the corresponding value should be "uniform". The parameter dictionary 
+    should also have the following keys:
+        "min"
+        "max"
+        "sample_size"
+        "log_scale"
+    "min" and "max" specify the minimum and maximum value of the parameter, respectively. 
+    "sample_size" specifies the number of parameter values we generate. Finally, log_scale, if 
+    true, specifies if we should use a uniform or logarithmic spacing between samples of the 
+    parameter.
+    
+    The values corresponding to "min" and "max" should be floats while the values corresponding to 
+    "sample_size" and "log_scale" should be an int and a bool, respectively. 
+
+    
+    -----------------------------------------------------------------------------------------------
+    Arguments
+    -----------------------------------------------------------------------------------------------
+
+    param_dict: A dictionary specifying one of the parameters. We should fetch this from the 
+    configuration yaml file. It must have a "min", "max", "sample_size", and "log_scale" 
+    keys (see above).
+
+
+    -----------------------------------------------------------------------------------------------
+    Returns
+    -----------------------------------------------------------------------------------------------
+
+    Two arguments: Nx and paramRange. paramRange is a 1d numpy ndarray (whose ith value is the 
+    i'th possible value of the parameter. Thus, paramRange[0] = param_dict["min"] and 
+    paramRange[-1] = param_dict["max"]). Nx is the length of paramRange or, equivalently 
+    param_dict["sample_size"]. 
+    """
+
+    # Fetch the number of samples and the min/max value for this parameter.
+    Nx      : int   = param_dict['sample_size']
+    minval  : float = param_dict['min']
+    maxval  : float = param_dict['max']
+
+    # Generate the range of parameter values. Note that we have to generate a uniform grid in the 
+    # log space, then exponentiate it to generate logarithmic spacing.
+    if (param_dict['log_scale']):
+        paramRange : np.ndarray = np.exp(np.linspace(np.log(minval), np.log(maxval), Nx))
     else:
-        paramRange = np.linspace(minval, maxval, Nx)
+        paramRange : np.ndarray = np.linspace(minval, maxval, Nx)
+    
+    # All done! 
     return Nx, paramRange
 
-getParam1DSpace = {'list': get_1dspace_from_list,
-                   'uniform': create_uniform_1dspace}
+
+
+# A macro that allows us to switch function we use to generate generate a parameter's range. 
+getParam1DSpace : dict[str, callable]    = {'list'       : get_1dspace_from_list,
+                                            'uniform'    : create_uniform_1dspace}
+
+
+
+# -------------------------------------------------------------------------------------------------
+# ParameterSpace Class
+# -------------------------------------------------------------------------------------------------
 
 class ParameterSpace:
-    param_list = []
-    param_name = []
-    n_param = 0
-    train_space = None
-    test_space = None
-    n_init = 0
-    test_grid_sizes = []
-    test_meshgrid = None
+    # Initialize class variables
+    param_list      : list[dict]        = []    # A list housing the parameter dictionaries (from the yml file)
+    param_name      : list[str]         = []    # A list housing the parameter names.
+    n_param         : int               = 0     # The number of parameters.
+    train_space     : np.ndarray        = None  # A 2D array of shape (n_train, n_param) whose i,j element is the j'th parameter value in the i'th combination of training parameters.
+    test_space      : np.ndarray        = None  # A 2D array of shape (n_test, n_param) whose i,j element is the j'th parameter value in the i'th combination of testing parameters.
+    n_init          : int               = 0     # The number of combinations of parameters in the training set???
+    test_grid_sizes : list[int]         = []    # A list whose i'th element is the number of different values of the i'th parameter in the test instances.
+    test_meshgrid   : tuple[np.ndarray] = None
 
-    def __init__(self, config):
-        assert('parameter_space' in config)
-        parser = InputParser(config['parameter_space'], name="param_space_input")
 
-        self.param_list = parser.getInput(['parameters'], datatype=list)
-        self.n_param = len(self.param_list)
 
-        self.param_name = []
+    def __init__(self, config : dict) -> None:
+        """
+        Initializes a ParameterSpace object using the settings passed in the conf dictionary (which 
+        should have been read from a yaml file).
+
+        
+        
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        config: This is a dictionary that houses the settings we want to use to run the code. This 
+        should have been read from a yaml file. We assume it contains the following keys. If one 
+        or more keys are tabbed over relative to one key above them, then the one above is a 
+        dictionary and the ones below should be keys within that dictionary.
+            - parameter_space
+                - parameters (this should have at least one parameter defined!)
+            - test_space
+                - type (should be "grid")
+        """
+
+        # Make sure the configuration dictionary has a "parameter_space" setting. This should house 
+        # information about which variables are present in the code, as well as how we want to test
+        # the various possible parameter values. 
+        assert('parameter_space' in config);
+
+        # Load the parameter_space settings into an InputParser object (which makes it easy to 
+        # fetch setting values). We then fetch the list of parameters. Each parameters has a name, 
+        # min and max, and information on how many instances we want. 
+        parser                          = InputParser(config['parameter_space'],    name        = "param_space_input")
+        self.param_list : list[dict]    = parser.getInput(['parameters'],           datatype    = list)
+
+        # Fetch the parameter names.
+        self.param_name : list[str]     = []
         for param in self.param_list:
-            self.param_name += [param['name']]
+            self.param_name += [param['name']];
 
-        self.train_space = self.createInitialTrainSpace(self.param_list)
-        self.n_init = self.train_space.shape[0]
+        # First, let's fetch the set of possible parameter values. This yields a 2^k x k matrix,
+        # where k is the number of parameters. The i,j entry of this matrix gives the value of the 
+        # j'th parameter on the i'th instance.
+        self.train_space    = self.createInitialTrainSpace(self.param_list)
+        self.n_init         = self.train_space.shape[0]
 
-        test_space_type = parser.getInput(['test_space', 'type'], datatype=str)
+        # Next, let's make a set of possible parameter values to test at.
+        test_space_type = parser.getInput(['test_space', 'type'], datatype = str)
         if (test_space_type == 'grid'):
+            # Generate the set possible parameter combinations. See the docstring for 
+            # "createTestGridSpace" for details.
             self.test_grid_sizes, self.test_meshgrid, self.test_space = self.createTestGridSpace(self.param_list)
 
+        # All done!
         return
     
-    def n_train(self):
+
+
+    def n_train(self) -> int:
+        """
+        Returns the number of combinations of parameters in the training set.
+        """
+
         return self.train_space.shape[0]
     
-    def n_test(self):
-        return self.test_space.shape[0]
-    
-    def createInitialTrainSpace(self, param_list):
-        paramRanges = []
 
-        for param in param_list:
-            minval = param['min']
-            maxval = param['max']
+
+    def n_test(self) -> int:
+        """
+        Returns the number of combinations of parameters in the testing set.
+        """
+
+        return self.test_space.shape[0]
+
+
+
+    def createInitialTrainSpace(self, param_list : list[dict]) -> np.ndarray:
+        """
+        Sets up a grid of parameter values to train at. Note that we only use the min and max value
+        of each parameter when setting up this grid.
+
+
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        param_list: A list of parameter dictionaries. Each entry should be a dictionary with the 
+        following keys:
+            - name
+            - min
+            - max
+        
+            
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        A 2d array of shape ((2)^k, k), where k is the number of parameters (k == len(param_list)).
+        The i'th column is the flattened i'th mesh_grid array we when we create a mesh grid using 
+        the min and max value of each parameter as the argument. See "createHyperMeshGrid" for 
+        details. 
+        
+        Specifically, we return exactly what "createHyperGridSpace" returns. See the doc-string 
+        for that function for further details. 
+        """
+
+        # We need to know the min and max value for each parameter to set up the grid of possible 
+        # parameter values.
+        paramRanges : list[np.ndarray] = []
+
+        for param in param_list:    
+            # Fetch the min, max value of the current parameter. 
+            minval  : float = param['min']
+            maxval  : float = param['max']
+            
+            # Store these values in an array and add them to the list.
             paramRanges += [np.array([minval, maxval])]
 
-        mesh_grids = self.createHyperMeshGrid(paramRanges)
+        # Use the ranges to set up a grid of possible parameter values.
+        mesh_grids : tuple[np.ndarray]  = self.createHyperMeshGrid(paramRanges)
+
+        # Now combine these grids into a 2d 
         return self.createHyperGridSpace(mesh_grids)
     
-    def createTestGridSpace(self, param_list):
-        paramRanges = []
-        gridSizes = []
 
+
+    def createTestGridSpace(self, param_list : list[dict]) -> tuple[list[int], tuple[np.ndarray], np.ndarray]:
+        """
+        This function sets up a grid of parameter values to test at. 
+
+
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        param_list: A list of parameter dictionaries. Each dictionary should either use the 
+        "uniform" or "list" format. See create_uniform_1dspace and get_1dspace_from_list, 
+        respectively.
+
+
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        A three element tuple. 
+        
+        The first is a list whose i'th element specifies the number of distinct values of the i'th 
+        parameter we consider (this is the length of the i'th element of "paramRanges" below).
+
+        The second is a a tuple of k numpy ndarrays (where k = len(param_list)), the i'th one of 
+        which is a k-dimensional array with shape (N0, ... , N{k - 1}), where Ni = 
+        param_list[i].size whose i(0), ... , i(k - 1) element specifies the value of the i'th 
+        parameter in the i(0), ... , i(k - 1)'th unique combination of parameter values.
+
+        The third one is a 2d array of parameter values. It has shape (M, k), where 
+        M = \prod_{i = 0}^{k - 1} param_list[i].size. 
+        """
+
+        # Set up arrays to hold the parameter values + number of parameter values for each 
+        # parameter.
+        paramRanges : np.ndarray    = []
+        gridSizes   : list[int]     = []
+
+        # Cycle through the parameters        
         for param in param_list:
-            Nx, paramRange = getParam1DSpace[param['test_space_type']](param)
-            gridSizes += [Nx]
-            paramRanges += [paramRange]
+            # Fetch the set of possible parameter values (paramRange) + the size of this set (Nx)
+            Nx, paramRange  = getParam1DSpace[param['test_space_type']](param)
 
-        mesh_grids = self.createHyperMeshGrid(paramRanges)
+            # Add Nx, ParamRange to their corresponding lists
+            gridSizes      += [Nx]
+            paramRanges    += [paramRange]
+
+        # Now that we have the set of parameter values for each parameter, turn it into a grid.
+        mesh_grids : tuple[np.ndarray] = self.createHyperMeshGrid(paramRanges)
+
+        # All done. Return a list specifying the number of possible values for each parameter, the
+        # grids of parameter values, and the flattened/2d version of it. 
         return gridSizes, mesh_grids, self.createHyperGridSpace(mesh_grids)
     
+
+
     def getParameter(self, param_vector):
         '''
             convert numpy array parameter vector to a dict.
@@ -91,63 +318,210 @@ class ParameterSpace:
 
         return param
     
-    def createHyperMeshGrid(self, param_ranges):
+
+
+    def createHyperMeshGrid(self, param_ranges : list[np.ndarray]) -> tuple[np.ndarray]:
         '''
-            param_ranges: list of numpy 1d arrays, each corresponding to 1d parameter grid space.
-                          The list size is equal to the number of parameters.
-            
-            Output: paramSpaces
-                - tuple of numpy nd arrays, corresponding to each parameter.
-                  Dimension of the array equals to the number of parameters
+        This function generates arrays of parameter values. Specifically, if there are k 
+        parameters (param_ranges has k elements), then we return k k-d arrays, the i'th one of 
+        which is a k-dimensional array whose i(0), ... , i(k - 1) element specifies the value of 
+        the i'th variable in the i(0), ... , i(k - 1)'th unique combination of parameter values.
+
+
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        param_ranges: list of numpy 1d arrays, each corresponding to 1d parameter grid space. The 
+        i'th element of this list should be a 2-element numpy.ndarray object housing the max and 
+        min value for the i'th parameter. The list size should equal the number of parameters. 
+                        
+
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        the "paramSpaces" tuple. This is a tuple of numpy ndarray objects, the i'th one of which 
+        gives the grid of parameter values for the i'th parameter. Specifically, if there are 
+        k parameters and if param_range[i].size = Ni, then the j'th return array has shape 
+        (N0, ... , N{k - 1}) and the i(0), ... , i(k - 1) element of this array houses the i(j)'th 
+        value of the j'th parameter.
+
+        Thus, if there are k parameters, the returned tuple has k elements, each one of 
+        which is an array of shape (N0, ... , N{k - 1}).
         '''
-        args = ()
+
+        # Fetch the ranges, add them to a tuple (this is what the meshgrid function needs).
+        args : tuple[np.ndarray] = ()
         for paramRange in param_ranges:
             args += (paramRange,)
 
-        paramSpaces = np.meshgrid(*args, indexing='ij')
+        # Use numpy's meshgrid function to generate the grids of parameter values.
+        paramSpaces : tuple[np.ndarray] = np.meshgrid(*args, indexing='ij')
+
+        # All done!
         return paramSpaces
     
-    def createHyperGridSpace(self, mesh_grids):
-        '''
-            mesh_grids: tuple of numpy nd arrays, corresponding to each parameter.
-                        Dimension of the array equals to the number of parameters
-            
-            Output: param_grid
-                - numpy 2d array of size (grid size x number of parameters).
 
-                grid size is the size of a numpy nd array.
+
+    def createHyperGridSpace(self, mesh_grids : tuple[np.ndarray]) -> np.ndarray:
         '''
-        param_grid = None
+        Flattens the mesh_grid numpy.ndarray objects returned by createHyperMeshGrid and combines 
+        them into a single 2d array of shape (grid size, number of parameters) (see below).
+
+
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        mesh_grids: tuple of numpy nd arrays, corresponding to each parameter. This should ALWAYS
+        be the output of the "CreateHyperMeshGrid" function. See the return section of that 
+        function's docstring for details.
+    
+        
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+        
+        The param_grid. This is a 2d numpy.ndarray object of shape (grid size, number of 
+        parameters). If each element of mesh_grids is a numpy.ndarray object of shape (N(1), ... , 
+        N(k)) (k parameters), then (grid size) = N(1)*N(2)*...*N(k) and (number of parameters) = k.
+        '''
+
+        # For each parameter, we flatten its mesh_grid into a 1d array (of length (grid size)). We
+        # horizontally stack these flattened grids to get the final param_grid array.
+        param_grid : np.ndarray = None
         for k, paramSpace in enumerate(mesh_grids):
+            # Special treatment for the first parameter to initialize param_grid
             if (k == 0):
-                param_grid = paramSpace.reshape(-1, 1)
+                param_grid : np.ndarray = paramSpace.reshape(-1, 1)
                 continue
 
-            param_grid = np.hstack((param_grid, paramSpace.reshape(-1, 1)))
+            # Flatten the new mesh grid and append it to the grid.
+            param_grid : np.ndarray = np.hstack((param_grid, paramSpace.reshape(-1, 1)))
 
+        # All done!
         return param_grid
     
-    def appendTrainSpace(self, param):
+
+
+    def appendTrainSpace(self, param : np.ndarray) -> None:
+        """
+        Adds a new parameter to self's train space attribute.
+
+
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        param: A 1d numpy ndarray object. It should have shape (n_param) and should hold a 
+        parameter value that we want to add to the training set.
+
+
+
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        Nothing!
+        """
+
+        # Make sure param has n_param components/can be appended to the set of training parameters.
         assert(self.train_space.shape[1] == param.size)
 
-        self.train_space = np.vstack((self.train_space, param))
+        # Add the new parameter to the training space by appending it as a new row to 
+        # self.train_space
+        self.train_space    : np.ndarray    = np.vstack((self.train_space, param))
+        
+        # All done!
         return
     
-    def export(self):
-        dict_ = {'train_space': self.train_space,
-                 'test_space': self.test_space,
-                 'test_grid_sizes': self.test_grid_sizes,
-                 'test_meshgrid': self.test_meshgrid,
-                 'n_init': self.n_init}
+
+
+    def export(self) -> dict:
+        """
+        This function packages the testing/training examples into a dictionary, which it returns.
+
+        
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        None!
+
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        A dictionary with 4 keys. Below is a list of the keys with a short description of each 
+        corresponding value. 
+            train_space: self.train_space, a 2d array of shape (n_train, n_param) whose i,j element 
+            holds the value of the j'th parameter in the i'th training case.
+
+            test_space: self.test_space, a 2d array of shape (n_test, n_param) whose i,j element 
+            holds the value of the j'th parameter in the i'th testing case.
+
+            test_grid_sizes: A list whose i'th element specifies how many distinct parameter values
+            we use for the i'th parameter. 
+
+            test_meshgrid: a tuple of n_param numpy.ndarray array objects whose i'th element is a
+            n_param-dimensional array whose i(1), i(2), ... , i(n_param) element holds the value of 
+            the i'th parameter in the i(1), ... , i(n_param) combination of parameter values in the 
+            testing test. 
+
+            n_init: The number of combinations of training parameters in the training set.     
+        """
+
+        # Build the dictionary
+        dict_ = {'train_space'      : self.train_space,
+                 'test_space'       : self.test_space,
+                 'test_grid_sizes'  : self.test_grid_sizes,
+                 'test_meshgrid'    : self.test_meshgrid,
+                 'n_init'           : self.n_init}
+        
+        # All done!
         return dict_
     
-    def load(self, dict_):
-        self.train_space = dict_['train_space']
-        self.test_space = dict_['test_space']
-        self.test_grid_sizes = dict_['test_grid_sizes']
-        self.test_meshgrid = dict_['test_meshgrid']
 
-        assert(self.n_init == dict_['n_init'])
-        assert(self.train_space.shape[1] == self.n_param)
-        assert(self.test_space.shape[1] == self.n_param)
+
+    def load(self, dict_ : dict) -> None:
+        """
+        This function builds a parameter space object from a dictionary. This dictionary should 
+        be one that was returned by th export method, or a loaded copy of a dictionary that was 
+        returned by the export method. 
+
+
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        dict_: This should be a dictionary with the following keys: 
+            - train_space
+            - test_space
+            - test_grid_sizes
+            - test_meshgrid
+            - n_init
+        This dictionary should have been returned by the export method. We use the values in this 
+        dictionary to set up self.
+
+        
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        Nothing!
+        """
+
+        # Extract information from the dictionary.
+        self.train_space        : np.ndarray        = dict_['train_space']
+        self.test_space         : np.ndarray        = dict_['test_space']
+        self.test_grid_sizes    : list[int]         = dict_['test_grid_sizes']
+        self.test_meshgrid      : tuple[np.ndarray] = dict_['test_meshgrid']
+
+        # Run checks
+        assert(self.n_init                  == dict_['n_init'])
+        assert(self.train_space.shape[1]    == self.n_param)
+        assert(self.test_space.shape[1]     == self.n_param)
+
+        # All done!
         return

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -22,6 +22,7 @@ getParam1DSpace = {'list': get_1dspace_from_list,
 class ParameterSpace:
     param_list = []
     param_name = []
+    n_param = 0
     train_space = None
     test_space = None
     n_test = 0
@@ -35,6 +36,7 @@ class ParameterSpace:
         parser = InputParser(config['parameter_space'], name="param_space_input")
 
         self.param_list = parser.getInput(['parameters'], datatype=list)
+        self.n_param = len(self.param_list)
 
         self.param_name = []
         for param in self.param_list:
@@ -131,13 +133,23 @@ class ParameterSpace:
         return
     
     def export(self):
-        dict_ = {'final_param_train': self.train_space,
-                 'param_grid': self.test_space,
+        dict_ = {'train_space': self.train_space,
+                 'test_space': self.test_space,
                  'test_grid_sizes': self.test_grid_sizes,
                  'test_meshgrid': self.test_meshgrid,
                  'n_init': self.n_init}
         return dict_
     
-    def loadTrainSpace(self):
-        raise RuntimeError("ParameterSpace.loadTrainSpace is not implemented yet!")
+    def load(self, dict_):
+        self.train_space = dict_['train_space']
+        self.test_space = dict_['test_space']
+        self.test_grid_sizes = dict_['test_grid_sizes']
+        self.test_meshgrid = dict_['test_meshgrid']
+
+        assert(self.n_init == dict_['n_init'])
+        assert(self.train_space.shape[1] == self.n_param)
+        assert(self.test_space.shape[1] == self.n_param)
+
+        self.n_train = self.train_space.shape[0]
+        self.n_test = self.test_space.shape[0]
         return

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -90,7 +90,9 @@ class OfflineFOM(Physics):
         self.qdim = parser.getInput(['solution_dimension'], datatype=int)
 
         self.grid_size = parser.getInput(['grid_size'], datatype=list)
-        self.qgrid_size = [self.qdim] + self.grid_size
+        self.qgrid_size = self.grid_size
+        if (self.qdim > 1):
+            self.qgrid_size = [self.qdim] + self.qgrid_size
         assert(self.dim == len(self.grid_size))
 
         #TODO(kevin): a general file loading for spatial grid
@@ -107,3 +109,8 @@ class OfflineFOM(Physics):
     def generate_solutions(self, params):
         raise RuntimeError("OfflineFOM does not support generate_solutions!!")
         return
+
+    def export(self):
+        dict_ = {'t_grid' : self.t_grid, 'x_grid' : self.x_grid, 'dt' : self.dt}
+        return dict_
+

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -63,6 +63,7 @@ class Physics:
         X_train = None
         for k, param in enumerate(params):
             new_X = self.solve(param)
+            assert(new_X.size(0) == 1) # should contain one parameter case.
             if (X_train is None):
                 X_train = new_X
             else:
@@ -75,3 +76,34 @@ class Physics:
     def residual(self, Xhist):
         raise RuntimeError("Abstract method Physics.residual!")
         return res, res_norm
+    
+class OfflineFOM(Physics):
+    def __init__(self, param_space, cfg):
+        super().__init__(param_space, cfg)
+        self.offline = True
+
+        assert('offline_fom' in cfg)
+        from ..inputs import InputParser
+        parser = InputParser(cfg['offline_fom'], name="offline_fom_input")
+
+        self.dim = parser.getInput(['space_dimension'], datatype=int)
+        self.qdim = parser.getInput(['solution_dimension'], datatype=int)
+
+        self.grid_size = parser.getInput(['grid_size'], datatype=list)
+        self.qgrid_size = [self.qdim] + self.grid_size
+        assert(self.dim == len(self.grid_size))
+
+        #TODO(kevin): a general file loading for spatial grid
+        #             There can be unstructured grids as well.
+        self.x_grid = None
+
+        # Assume uniform time stepping for now.
+        self.nt = parser.getInput(['number_of_timesteps'], datatype=int)
+        self.dt = parser.getInput(['timestep_size'], datatype=float)
+        self.t_grid = np.linspace(0.0, (self.nt-1) * self.dt, self.nt)
+
+        return
+    
+    def generate_solutions(self, params):
+        raise RuntimeError("OfflineFOM does not support generate_solutions!!")
+        return

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -57,6 +57,7 @@ class Physics:
         params.shape[1] must match the required size of
         parameters for the specific physics.
         '''
+        assert(params.ndim == 2)
         n_param = len(params)
         print("Generating %d samples" % n_param)
 

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -31,11 +31,11 @@ class Physics:
     # Set at the initialization.
     offline = False
 
-    # ParameterSpace object to parse parameters.
-    param_space = None
+    # list of parameter names to parse parameters.
+    param_name = None
 
-    def __init__(self, param_space, cfg):
-        self.param_space = param_space
+    def __init__(self, cfg, param_name=None):
+        self.param_name = param_name
         return
     
     def initial_condition(self, param):
@@ -78,8 +78,8 @@ class Physics:
         return res, res_norm
     
 class OfflineFOM(Physics):
-    def __init__(self, param_space, cfg):
-        super().__init__(param_space, cfg)
+    def __init__(self, cfg, param_name=None):
+        super().__init__(cfg, param_name)
         self.offline = True
 
         assert('offline_fom' in cfg)

--- a/src/lasdi/physics/burgers1d.py
+++ b/src/lasdi/physics/burgers1d.py
@@ -7,8 +7,11 @@ from . import Physics
 from ..fd import FDdict
 
 class Burgers1D(Physics):
-    def __init__(self, param_space, cfg):
-        super().__init__(param_space, cfg)
+    a_idx = None # parameter index for a
+    w_idx = None # parameter index for w
+
+    def __init__(self, cfg, param_name=None):
+        super().__init__(cfg, param_name)
 
         self.qdim = 1
         self.dim = 1
@@ -36,12 +39,20 @@ class Burgers1D(Physics):
 
         self.maxk = parser.getInput(['maxk'], fallback=10)
         self.convergence_threshold = parser.getInput(['convergence_threshold'], fallback=1.e-8)
+
+        if (self.param_name is not None):
+            if 'a' in self.param_name:
+                self.a_idx = self.param_name.index('a')
+            if 'w' in self.param_name:
+                self.w_idx = self.param_name.index('w')
         return
     
     def initial_condition(self, param):
-        param = self.param_space.getParameter(param)
-        a = param['a'] if 'a' in param else 1.0
-        w = param['w'] if 'w' in param else 1.0
+        a, w = 1.0, 1.0
+        if 'a' in self.param_name:
+            a = param[self.a_idx]
+        if 'w' in self.param_name:
+            w = param[self.w_idx]
 
         return a * np.exp(- self.x_grid ** 2 / 2 / w / w)
     
@@ -153,7 +164,7 @@ def main():
     # initialize parameter space and physics class
     from ..param import ParameterSpace
     param_space = ParameterSpace(config)
-    physics = Burgers1D(param_space, config['physics'])
+    physics = Burgers1D(config['physics'], param_space.param_name)
 
     # read training parameter points
     train_param_file = cfg_parser.getInput(['workflow', 'offline_greedy_sampling', 'train_param_file'], datatype=str)

--- a/src/lasdi/timing.py
+++ b/src/lasdi/timing.py
@@ -40,8 +40,22 @@ class Timer:
         return
     
     def export(self):
+        for start in self.starts:
+            if (start is not None):
+                raise RuntimeError('Timer.export: cannot export while Timer is still ticking!')
+
         param_dict = {}
         param_dict["names"] = self.names
         param_dict["calls"] = self.calls
         param_dict["times"] = self.times
         return param_dict
+    
+    def load(self, dict_):
+        self.names = dict_['names']
+        self.calls = dict_['calls']
+        self.times = dict_['times']
+
+        assert(len(self.names) == len(self.calls))
+        assert(len(self.names) == len(self.times))
+        self.starts = [None] * len(self.names)
+        return

--- a/src/lasdi/workflow.py
+++ b/src/lasdi/workflow.py
@@ -9,6 +9,7 @@ from .latent_space import Autoencoder
 from .latent_dynamics.sindy import SINDy
 from .physics.burgers1d import Burgers1D
 from .param import ParameterSpace
+from .inputs import InputParser
 
 trainer_dict = {'gplasdi': BayesianGLaSDI}
 
@@ -29,63 +30,102 @@ def main():
 
     with open(args.config_file, 'r') as f:
         config = yaml.safe_load(f)
+        cfg_parser = InputParser(config, name='main')
 
-    trainer = initialize_trainer(config)
+    use_restart = cfg_parser.getInput(['workflow', 'use_restart'], fallback=False)
+    if (use_restart):
+        restart_filename = cfg_parser.getInput(['workflow', 'restart_file'], datatype=str)
+        from os.path import dirname
+        from pathlib import Path
+        Path(dirname(restart_filename)).mkdir(parents=True, exist_ok=True)
 
-    if ('restart_file' in config):
-        restart_file = np.load(config['restart_file'], allow_pickle=True).item()
-        next_step = restart_file['next_step']
+    import os
+    if (use_restart and (os.path.isfile(restart_filename))):
+        # TODO(kevin): in long term, we should switch to hdf5 format.
+        restart_file = np.load(restart_filename, allow_pickle=True).item()
+        current_step = restart_file['next_step']
         result = restart_file['result']
     else:
-        next_step = NextStep.Initial
+        restart_file = None
+        current_step = NextStep.Initial
         result = Result.Unexecuted
+    
+    trainer, param_space, physics, latent_space, latent_dynamics = initialize_trainer(config, restart_file)
+
+    result, next_step = step(trainer, current_step, config, use_restart)
 
     if (result is Result.Fail):
         raise RuntimeError('Previous step has failed. Stopping the workflow.')
+    elif (result is Result.Success):
+        print("Previous step succeeded. Preparing for the next step.")
+        result = Result.Unexecuted
     elif (result is Result.Complete):
         print("Workflow is finished.")
-        return result
 
-    result = step(trainer, next_step, config)
+    # save restart (or final) file.
+    import time
+    date = time.localtime()
+    date_str = "{month:02d}_{day:02d}_{year:04d}_{hour:02d}_{minute:02d}"
+    date_str = date_str.format(month = date.tm_mon, day = date.tm_mday, year = date.tm_year, hour = date.tm_hour + 3, minute = date.tm_min)
+    if (use_restart):
+        # rename old restart file if exists.
+        if (os.path.isfile(restart_filename)):
+            old_timestamp = restart_file['timestamp']
+            os.rename(restart_filename, restart_filename + '.' + old_timestamp)
+        save_file = restart_filename
+    else:
+        save_file = 'lasdi_' + date_str + '.npy'
+    
+    save_dict = {'parameters': param_space.export(),
+                 'physics': physics.export(),
+                 'latent_space': latent_space.export(),
+                 'latent_dynamics': latent_dynamics.export(),
+                 'trainer': trainer.export(),
+                 'timestamp': date_str,
+                 'next_step': next_step,
+                 'result': result, # TODO(kevin): do we need to save result?
+                 }
+    
+    np.save(save_file, save_dict)
 
     return result
 
-def step(trainer, next_step, config):
-    # TODO(kevin): implement save/load workflow.
-    continue_workflow = True
+def step(trainer, next_step, config, use_restart=False):
 
     if (next_step is NextStep.Initial):
 
         result, next_step = initial_step(trainer, config)
-        if (continue_workflow):
-            result = step(trainer, next_step, config)
 
     elif (next_step is NextStep.Train):
 
         result, next_step = trainer.train()
-        if (result is Result.Complete):
-            return result
-        else:
-            assert(next_step is NextStep.RunSample)
-            result = step(trainer, next_step, config)
 
     elif (next_step is NextStep.RunSample):
 
         trainer.sample_fom()
         # TODO(kevin): currently no offline fom simulation. skip CollectSample.
         result, next_step = Result.Success, NextStep.Train
-        result = step(trainer, next_step, config)
+        # result = step(trainer, next_step, config)
 
     elif (next_step is NextStep.CollectSample):
         import warnings
         warnings.warn("Collecting sample from offline FOM simulation is not implemented yet")
+        result, next_step = Result.Success, NextStep.RunSample
 
     else:
         raise RuntimeError("Unknown next step!")
+    
+    # if fail or complete, break the loop regardless of use_restart.
+    if ((result is Result.Fail) or (result is Result.Complete)):
+        return result, next_step
+    
+    # continue the workflow if not using restart.
+    if (not use_restart):
+        result, next_step = step(trainer, next_step, config)
 
-    return result
+    return result, next_step
 
-def initialize_trainer(config):
+def initialize_trainer(config, restart_file=None):
     '''
     Initialize a LaSDI class with a latent space model according to config file.
     Currently only 'gplasdi' is available.
@@ -93,23 +133,31 @@ def initialize_trainer(config):
 
     # TODO(kevin): load parameter train space from a restart file.
     param_space = ParameterSpace(config)
+    if (restart_file is not None):
+        param_space.load(restart_file['parameters'])
 
     physics = initialize_physics(param_space, config)
     latent_space = initialize_latent_space(physics, config)
+    if (restart_file is not None):
+        latent_space.load(restart_file['latent_space'])
 
     # do we need a separate routine for latent dynamics initialization?
     ld_type = config['latent_dynamics']['type']
     assert(ld_type in config['latent_dynamics'])
     assert(ld_type in ld_dict)
     latent_dynamics = ld_dict[ld_type](latent_space.n_z, physics.nt, config['latent_dynamics'])
+    if (restart_file is not None):
+        latent_dynamics.load(restart_file['latent_dynamics'])
 
     trainer_type = config['lasdi']['type']
     assert(trainer_type in config['lasdi'])
     assert(trainer_type in trainer_dict)
 
     trainer = trainer_dict[trainer_type](physics, latent_space, latent_dynamics, config['lasdi'][trainer_type])
+    if (restart_file is not None):
+        trainer.load(restart_file['trainer'])
 
-    return trainer
+    return trainer, param_space, physics, latent_space, latent_dynamics
 
 def initialize_latent_space(physics, config):
     '''

--- a/src/lasdi/workflow.py
+++ b/src/lasdi/workflow.py
@@ -149,7 +149,7 @@ def initialize_trainer(config, restart_file=None):
     if (restart_file is not None):
         param_space.load(restart_file['parameters'])
 
-    physics = initialize_physics(param_space, config)
+    physics = initialize_physics(config, param_space.param_name)
     latent_space = initialize_latent_space(physics, config)
     if (restart_file is not None):
         latent_space.load(restart_file['latent_space'])
@@ -166,7 +166,7 @@ def initialize_trainer(config, restart_file=None):
     assert(trainer_type in config['lasdi'])
     assert(trainer_type in trainer_dict)
 
-    trainer = trainer_dict[trainer_type](physics, latent_space, latent_dynamics, config['lasdi'][trainer_type])
+    trainer = trainer_dict[trainer_type](physics, latent_space, latent_dynamics, param_space, config['lasdi'][trainer_type])
     if (restart_file is not None):
         trainer.load(restart_file['trainer'])
 
@@ -188,7 +188,7 @@ def initialize_latent_space(physics, config):
 
     return latent_space
 
-def initialize_physics(param_space, config):
+def initialize_physics(config, param_name):
     '''
     Initialize a physics FOM model according to config file.
     Currently only 'burgers1d' is available.
@@ -196,7 +196,7 @@ def initialize_physics(param_space, config):
 
     physics_cfg = config['physics']
     physics_type = physics_cfg['type']
-    physics = physics_dict[physics_type](param_space, physics_cfg)
+    physics = physics_dict[physics_type](physics_cfg, param_name)
 
     return physics
 


### PR DESCRIPTION
I added documentation (comments + doc strings + type hints + formatting) to latent_space.py

The code is functionally almost identical, save for a few minor tweaks:
- Removed the MultiHeadAttention activation function option. This isn't really an activation function, even though it is listed as such in the torch api. It is used to implement an attention layer in a transformer block. It introduces a whole new set of parameters (for the key, query, and value weight matrices) and is really designed to map finite sequences to finite sequences. I do not think it makes sense to include this in the MLP class as an activation option, so I removed it.

- Removed apply_attention. Since there is no more multiheadedattention activation option, this function should be removed. 

Otherwise, all changes are cosmetic (e.g., comments + formatting). 

I also fixed a small bug in gplasdi.py: np.Inf no longer exists. It is deprecated. It has been replaced with np.inf. I fixed this.