### PR TITLE
Latent space documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ on:
       - main
 
 jobs:
-  docker-image:
-    uses: ./.github/workflows/docker.yml
+  # docker-image:
+  #   uses: ./.github/workflows/docker.yml
   api-doc:
-    needs: [docker-image]
+    # needs: [docker-image]
     uses: ./.github/workflows/sphinx.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+jobs:
+  docker-image:
+    uses: ./.github/workflows/docker.yml
+  api-doc:
+    needs: [docker-image]
+    uses: ./.github/workflows/sphinx.yml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,69 @@
+name: docker-image
+on:
+  workflow_call:
+
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: LLNL/GPLaSDI/lasdi_env
+  DOCKERPATH: docker
+
+jobs:
+  docker-ci:
+    runs-on: ubuntu-latest
+    name: "docker env"
+    env:
+      DOCKERPATH: docker
+    steps:
+      - name: test command
+        run: echo "docker-ci command"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: Ana06/get-changed-files@v2.2.0       
+        id: files
+      - name: DockerPATH configuration
+        run: echo "DOCKERPATH=$DOCKERPATH"
+      - name: DockerPATH - check if files in docker path changed
+        if: contains(steps.files.outputs.all,env.DOCKERPATH) || contains(steps.files.outputs.all,'docker.yml')
+        run: |
+          echo "CI container needs rebuilding..."
+          echo "CI_NEEDS_REBUILD=true" >> $GITHUB_ENV
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: env.CI_NEEDS_REBUILD
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        if: env.CI_NEEDS_REBUILD
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=sha
+          flavor: latest=true
+      - name: Build Container motd
+        if: env.CI_NEEDS_REBUILD
+        run: |
+          echo "#!/bin/bash" > ${{env.DOCKERPATH}}/motd.sh
+          echo "echo --------------------------" >> ${{env.DOCKERPATH}}/motd.sh
+          echo "echo lasdi_env/CI Development Container"  >> ${{env.DOCKERPATH}}/motd.sh
+          echo "echo \"Revision: `echo ${GITHUB_SHA} | cut -c1-8`\"" >> ${{env.DOCKERPATH}}/motd.sh
+          echo "echo --------------------------" >> ${{env.DOCKERPATH}}/motd.sh
+          chmod 755 ${{env.DOCKERPATH}}/motd.sh
+          cat ${{env.DOCKERPATH}}/motd.sh
+      - name: Docker Image - Build and push
+        if: env.CI_NEEDS_REBUILD
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: ${{ env.DOCKERPATH }}
+          tags: ${{ steps.meta.outputs.tags }}
+          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -7,11 +7,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/llnl/gplasdi/lasdi_env:latest
-      options: --user 1001 --privileged
-      volumes:
-        - /mnt:/mnt
+    # container:
+    #   image: ghcr.io/llnl/gplasdi/lasdi_env:latest
+    #   options: --user 1001 --privileged
+    #   volumes:
+    #     - /mnt:/mnt
     permissions:
       contents: write
     steps:
@@ -20,15 +20,15 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - uses: actions/checkout@v4
-    - name: check autoapi.extension
-      run: |
-          python -m autoapi.extension
+    # - name: check autoapi.extension
+    #   run: |
+    #       python -m autoapi.extension
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
-        build-command: "sphinx-build -b html . build"
-        pre-build-command: "pip install sphinx-autoapi sphinx_rtd_theme"
+        build-command: "sphinx-build -b html source build"
+        pre-build-command: "pip install --upgrade pip && pip install sphinx-autoapi sphinx_rtd_theme"
       # run: |
       #     sphinx-build --version
       #     cd ${GITHUB_WORKSPACE}/docs

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -24,7 +24,10 @@ jobs:
       run: |
           python -m autoapi.extension
     - name: Build HTML
-      uses: ammaraskar/sphinx-action@master
+      # uses: ammaraskar/sphinx-action@master
+      run: |
+          sphinx-build --version
+          sphinx-build -b html source/ build/
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -36,17 +36,15 @@ jobs:
       #     sphinx-build -b html source/ build/
     - name: check resulting files
       run: |
-          ls ${GITHUB_WORKSPACE}/docs/
           ls ${GITHUB_WORKSPACE}/docs/build
-          ls ${GITHUB_WORKSPACE}/docs/build/html
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: html-docs
-        path: docs/build/html/
+        path: docs/build/
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       # if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/build/html
+        publish_dir: docs/build

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -41,7 +41,7 @@ jobs:
         path: docs/build/
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/main'
+      # if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,13 +1,24 @@
 name: "Sphinx: Render docs"
 
-on: push
+# on: push
+on:
+  workflow_call:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/llnl/gplasdi/lasdi_env:latest
+      options: --user 1001 --privileged
+      volumes:
+        - /mnt:/mnt
     permissions:
       contents: write
     steps:
+    - name: Cancel previous runs
+      uses: styfle/cancel-workflow-action@0.11.0
+      with:
+        access_token: ${{ github.token }}
     - uses: actions/checkout@v4
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -41,7 +41,7 @@ jobs:
         path: docs/build/
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
-      # if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -34,6 +34,11 @@ jobs:
       #     cd ${GITHUB_WORKSPACE}/docs
       #     mkdir build
       #     sphinx-build -b html source/ build/
+    - name: check resulting files
+      run: |
+          ls ${GITHUB_WORKSPACE}/docs/
+          ls ${GITHUB_WORKSPACE}/docs/build
+          ls ${GITHUB_WORKSPACE}/docs/build/html
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -20,9 +20,6 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - uses: actions/checkout@v4
-    # - name: check autoapi.extension
-    #   run: |
-    #       python -m autoapi.extension
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master
       with:
@@ -44,7 +41,7 @@ jobs:
         path: docs/build/
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
-      # if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,0 +1,24 @@
+name: "Sphinx: Render docs"
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build HTML
+      uses: ammaraskar/sphinx-action@master
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-docs
+        path: docs/build/html/
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      # if: github.ref == 'refs/heads/main'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/build/html

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -24,10 +24,16 @@ jobs:
       run: |
           python -m autoapi.extension
     - name: Build HTML
-      # uses: ammaraskar/sphinx-action@master
-      run: |
-          sphinx-build --version
-          sphinx-build -b html source/ build/
+      uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"
+        build-command: "sphinx-build -b html . build"
+        pre-build-command: "pip install sphinx-autoapi sphinx_rtd_theme"
+      # run: |
+      #     sphinx-build --version
+      #     cd ${GITHUB_WORKSPACE}/docs
+      #     mkdir build
+      #     sphinx-build -b html source/ build/
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         access_token: ${{ github.token }}
     - uses: actions/checkout@v4
+    - name: check autoapi.extension
+      run: |
+          python -m autoapi.extension
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master
     - name: Upload artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ examples/results
 examples/checkpoint
 *.npy
 build
+docs/build

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ This python package requires updated prerequistes:
 "scipy>=1.13.1",
 "pyyaml>=6.0",
 "matplotlib>=3.8.4",
-"argparse>=1.4.0"
+"argparse>=1.4.0",
+"h5py"
 ```
 
 ### For LLNL LC Lassen users

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,18 +11,19 @@ WORKDIR /$ENVDIR
 RUN sudo apt-get install -yq git
 RUN sudo apt-get install --no-install-recommends -yq make gcc gfortran libssl-dev cmake
 RUN sudo apt-get install -yq libopenblas-dev libmpich-dev libblas-dev liblapack-dev libscalapack-mpi-dev libhdf5-mpi-dev hdf5-tools
-RUN sudo apt-get install -yq vim
+# RUN sudo apt-get install -yq vim
 RUN sudo apt-get install -yq git-lfs
-RUN sudo apt-get install -yq valgrind
+# RUN sudo apt-get install -yq valgrind
 RUN sudo apt-get install -yq wget
-RUN sudo apt-get install -yq astyle
+# RUN sudo apt-get install -yq astyle
 
 # install python
 RUN sudo apt-get install -yq python3
 RUN sudo apt-get install -yq python3-dev
 RUN sudo apt-get install -yq python3-pip
-RUN sudo pip3 install --upgrade pip
-RUN sudo pip3 install sphinx-autoapi sphinx_rtd_theme
+RUN sudo apt-get install python-is-python3
+RUN sudo python -m pip install --upgrade pip
+RUN sudo python -m pip install sphinx-autoapi sphinx_rtd_theme
 #RUN sudo pip3 install numpy scipy argparse tables PyYAML h5py pybind11 pytest mpi4py merlin
 #
 RUN sudo apt-get clean -q

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN sudo apt-get install -yq python3-dev
 RUN sudo apt-get install -yq python3-pip
 RUN sudo apt-get install python-is-python3
 RUN sudo python -m pip install --upgrade pip
-RUN sudo python -m pip install sphinx-autoapi sphinx_rtd_theme
+RUN sudo python -m pip install sphinx sphinx-autoapi sphinx_rtd_theme
 #RUN sudo pip3 install numpy scipy argparse tables PyYAML h5py pybind11 pytest mpi4py merlin
 #
 RUN sudo apt-get clean -q

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:22.04
+
+ENV ENVDIR=env
+
+# install sudo
+RUN apt-get -yq update && apt-get -yq install sudo
+
+WORKDIR /$ENVDIR
+
+# install packages
+RUN sudo apt-get install -yq git
+RUN sudo apt-get install --no-install-recommends -yq make gcc gfortran libssl-dev cmake
+RUN sudo apt-get install -yq libopenblas-dev libmpich-dev libblas-dev liblapack-dev libscalapack-mpi-dev libhdf5-mpi-dev hdf5-tools
+RUN sudo apt-get install -yq vim
+RUN sudo apt-get install -yq git-lfs
+RUN sudo apt-get install -yq valgrind
+RUN sudo apt-get install -yq wget
+RUN sudo apt-get install -yq astyle
+
+# install python
+RUN sudo apt-get install -yq python3
+RUN sudo apt-get install -yq python3-dev
+RUN sudo apt-get install -yq python3-pip
+RUN sudo pip3 install --upgrade pip
+RUN sudo pip3 install sphinx-autoapi sphinx_rtd_theme
+#RUN sudo pip3 install numpy scipy argparse tables PyYAML h5py pybind11 pytest mpi4py merlin
+#
+RUN sudo apt-get clean -q
+
+# create and switch to a user
+ENV USERNAME=test
+RUN echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+RUN useradd --no-log-init -u 1001 --create-home --shell /bin/bash $USERNAME
+RUN adduser $USERNAME sudo
+USER $USERNAME
+WORKDIR /home/$USERNAME

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,8 +12,8 @@ sys.path.insert(0, os.path.abspath('..'))
 sys.path.insert(0, os.path.abspath('../../src'))
 
 project = 'LaSDI'
-copyright = '2024, Kevin Chung'
-author = 'Kevin Chung'
+copyright = '2023-2024, Lawrence Livermore National Security, LLC and other LaSDI project developers.'
+author = 'Christophe Bonneville, Kevin Chung, Youngsoo Choi'
 release = '2.0'
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,42 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os, sys
+sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../../src'))
+
+project = 'LaSDI'
+copyright = '2024, Kevin Chung'
+author = 'Kevin Chung'
+release = '2.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'autoapi.extension',
+    'sphinx.ext.napoleon',
+]
+
+autoapi_dirs = ['../../src']
+ 
+napoleon_google_docstring = False
+napoleon_use_param = False
+napoleon_use_ivar = True
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,5 +15,12 @@ It also supports parametric interpolation of latent dynamics according to uncert
    :maxdepth: 2
    :caption: Contents:
 
-   lasdi
+References
+===================
 
+* Fries, William D., Xiaolong He, and Youngsoo Choi. "LaSDI: Parametric latent space dynamics identification." Computer Methods in Applied Mechanics and Engineering 399 (2022): 115436.
+* He, Xiaolong, Youngsoo Choi, William D. Fries, Jonathan L. Belof, and Jiun-Shyan Chen. "gLaSDI: Parametric physics-informed greedy latent space dynamics identification." Journal of Computational Physics 489 (2023): 112267.
+* Tran, April, Xiaolong He, Daniel A. Messenger, Youngsoo Choi, and David M. Bortz. "Weak-form latent space dynamics identification." Computer Methods in Applied Mechanics and Engineering 427 (2024): 116998.
+* Park, Jun Sur Richard, Siu Wun Cheung, Youngsoo Choi, and Yeonjong Shin. "tLaSDI: Thermodynamics-informed latent space dynamics identification." arXiv preprint arXiv:2403.05848 (2024).
+* Bonneville, Christophe, Youngsoo Choi, Debojyoti Ghosh, and Jonathan L. Belof. "Gplasdi: Gaussian process-based interpretable latent space dynamics identification through deep autoencoder." Computer Methods in Applied Mechanics and Engineering 418 (2024): 116535.
+* He, Xiaolong, April Tran, David M. Bortz, and Youngsoo Choi. "Physics-informed active learning with simultaneous weak-form latent space dynamics identification." arXiv preprint arXiv:2407.00337 (2024).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,10 +6,10 @@
 LaSDI documentation
 ===================
 
-Add your content using ``reStructuredText`` syntax. See the
-`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
-documentation for details.
-
+LaSDI is a light-weight python package for Latent Space Dynamics Identification.
+LaSDI maps full-order PDE solutions to a latent space using autoencoders and learns the system of ODEs governing the latent space dynamics.
+By interpolating and solving the ODE system in the reduced latent space, fast and accurate ROM predictions can be made by feeding the predicted latent space dynamics into the decoder.
+It also supports parametric interpolation of latent dynamics according to uncertainties evaluated via Gaussian process.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,19 @@
+.. LaSDI documentation master file, created by
+   sphinx-quickstart on Wed Oct 16 22:11:53 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+LaSDI documentation
+===================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   lasdi
+

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -35,7 +35,7 @@
     "from lasdi.latent_space import Autoencoder, initial_condition_latent\n",
     "from lasdi.postprocess import compute_errors\n",
     "\n",
-    "filename = 'lasdi_09_11_2024_20_20.npy'"
+    "filename = 'lasdi_09_18_2024_20_51.npy'"
    ]
   },
   {
@@ -113,8 +113,7 @@
     "n_z = autoencoder_param['fc' + str(n_hidden + 1) + '_e.weight'].shape[0]\n",
     "\n",
     "autoencoder.load_state_dict(autoencoder_param)\n",
-    "Z = autoencoder.encoder(X_train)\n",
-    "coefs = sindy.calibrate(Z, physics.dt, compute_loss=False, numpy=True)\n",
+    "coefs = restart_file['trainer']['best_coefs']\n",
     "gp_dictionnary = fit_gps(param_space.train_space, coefs)\n",
     "\n",
     "n_coef = sindy.ncoefs\n",

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "d67dad03-9d76-4891-82ff-7e19d1369a24",
    "metadata": {},
    "outputs": [],
@@ -46,6 +46,7 @@
     "trainer, param_space, physics, autoencoder, sindy = initialize_trainer(config)\n",
     "\n",
     "# generate initial training/test data\n",
+    "pick_samples(trainer, config)\n",
     "run_samples(trainer, config)\n",
     "# initial training given training data\n",
     "trainer.train()\n",
@@ -77,7 +78,7 @@
    "outputs": [],
    "source": [
     "# Specify the restart file you have.\n",
-    "filename = 'lasdi_09_18_2024_20_51.npy'\n",
+    "filename = 'lasdi_10_01_2024_17_09.npy'\n",
     "\n",
     "import yaml\n",
     "from lasdi.workflow import initialize_trainer\n",
@@ -110,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "dcdac0c2",
    "metadata": {},
    "outputs": [],

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -16,13 +16,57 @@
   },
   {
    "cell_type": "markdown",
+   "id": "493f4313",
+   "metadata": {},
+   "source": [
+    "# Overall workflow and training\n",
+    "\n",
+    "Data generation/training can be performed by built-in executable `lasdi`. For this example of Burgers 1D equation, you can simply run on command-line terminal:\n",
+    "```\n",
+    "lasdi burgers1d.yml\n",
+    "```\n",
+    "\n",
+    "The workflow can be also manually constructed for those who prefer python scripts and for prototyping. Following code snippets show the high-level view of the workflow in the executable `lasdi`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ead8f2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from lasdi.workflow import initialize_trainer, run_samples, pick_samples\n",
+    "\n",
+    "cfg_file = 'burgers1d.yml'\n",
+    "with open(cfg_file, 'r') as f:\n",
+    "    config = yaml.safe_load(f)\n",
+    "\n",
+    "trainer, param_space, physics, autoencoder, sindy = initialize_trainer(config)\n",
+    "\n",
+    "# generate initial training/test data\n",
+    "run_samples(trainer, config)\n",
+    "# initial training given training data\n",
+    "trainer.train()\n",
+    "\n",
+    "while (trainer.restart_iter < trainer.max_iter):\n",
+    "    if (trainer.restart_iter <= trainer.max_greedy_iter):\n",
+    "        # perform greedy sampling to pick up new samples\n",
+    "        pick_samples(trainer, config)\n",
+    "        # update training data with newly picked samples\n",
+    "        run_samples(trainer, config)\n",
+    "\n",
+    "    # train over given training data\n",
+    "    trainer.train()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cfffced1",
    "metadata": {},
    "source": [
-    "We assume all data generation/training is complete. If not done yet, please run on the terminal:\n",
-    "```\n",
-    "lasdi burgers1d.yml\n",
-    "```"
+    "If you ran the command instead, a restart file is saved at the end of the training, which can be loaded for post-processing:"
    ]
   },
   {
@@ -32,27 +76,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lasdi.latent_space import Autoencoder, initial_condition_latent\n",
-    "from lasdi.postprocess import compute_errors\n",
+    "# Specify the restart file you have.\n",
+    "filename = 'lasdi_09_18_2024_20_51.npy'\n",
     "\n",
-    "filename = 'lasdi_09_18_2024_20_51.npy'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e1dfd2b6",
-   "metadata": {},
-   "source": [
-    "Initialize physics solver, according to the config file `burgers1d.yml`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "68f93c32",
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import yaml\n",
     "from lasdi.workflow import initialize_trainer\n",
     "from lasdi.param import ParameterSpace\n",
@@ -67,26 +93,77 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "42758da9",
+   "metadata": {},
+   "source": [
+    "# Post-processing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cf48489",
+   "metadata": {},
+   "source": [
+    "Load data for post-processing:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef6a1685",
+   "id": "dcdac0c2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lasdi.gp import fit_gps\n",
+    "coefs = trainer.best_coefs\n",
+    "X_train = trainer.X_train\n",
+    "X_test = trainer.X_test\n",
     "\n",
-    "autoencoder_param = restart_file['latent_space']['autoencoder_param']\n",
+    "param_train = param_space.train_space\n",
+    "param_grid = param_space.test_space\n",
+    "test_meshgrid = param_space.test_meshgrid\n",
+    "test_grid_sizes = param_space.test_grid_sizes\n",
+    "n_init = param_space.n_init\n",
     "\n",
+    "n_a_grid, n_w_grid = test_grid_sizes\n",
+    "a_grid, w_grid = test_meshgrid\n",
+    "\n",
+    "t_grid = physics.t_grid\n",
+    "x_grid = physics.x_grid\n",
+    "t_mesh, x_mesh = np.meshgrid(t_grid, x_grid)\n",
+    "Dt, Dx = physics.dt, physics.dx\n",
+    "\n",
+    "time_dim, space_dim = t_grid.shape[0], x_grid.shape[0]\n",
+    "\n",
+    "n_coef = sindy.ncoefs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2b6e720",
+   "metadata": {},
+   "source": [
+    "They can be also loaded directly from restart file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e796b0bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coefs = restart_file['trainer']['best_coefs']\n",
     "X_train = restart_file['trainer']['X_train']\n",
+    "X_test = restart_file['trainer']['X_test']\n",
     "\n",
     "paramspace_dict = restart_file['parameters']\n",
     "param_train = paramspace_dict['train_space']\n",
     "param_grid = paramspace_dict['test_space']\n",
     "test_meshgrid = paramspace_dict['test_meshgrid']\n",
     "test_grid_sizes = paramspace_dict['test_grid_sizes']\n",
-    "\n",
     "n_init = paramspace_dict['n_init']\n",
-    "n_samples = 20\n",
+    "\n",
     "n_a_grid, n_w_grid = test_grid_sizes\n",
     "a_grid, w_grid = test_meshgrid\n",
     "\n",
@@ -97,33 +174,38 @@
     "Dt = physics_dict['dt']\n",
     "Dx = physics_dict['dx']\n",
     "\n",
-    "# total_time = bglasdi_results['total_time']\n",
-    "# start_train_phase = bglasdi_results['start_train_phase']\n",
-    "# start_fom_phase = bglasdi_results['start_fom_phase']\n",
-    "# end_train_phase = bglasdi_results['end_train_phase']\n",
-    "# end_fom_phase = bglasdi_results['end_fom_phase']\n",
-    "\n",
-    "data_test = np.load('data/data_test.npy', allow_pickle = True).item()\n",
-    "X_test = data_test['X_test']\n",
-    "\n",
     "time_dim, space_dim = t_grid.shape[0], x_grid.shape[0]\n",
+    "n_coef = restart_file['latent_dynamics']['ncoefs']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1262a0c3",
+   "metadata": {},
+   "source": [
+    "## Gaussian-process uncertainty evaluation\n",
+    "We evaluated the uncertainties of latent dynamics coefficients over 2d parameter space, with samples from GP prediction:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef6a1685",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.gp import fit_gps\n",
+    "from lasdi.gplasdi import sample_roms, average_rom\n",
+    "from lasdi.postprocess import compute_errors\n",
+    "from lasdi.gp import eval_gp\n",
     "\n",
-    "n_hidden = len(autoencoder_param.keys()) // 4 - 1\n",
-    "hidden_units = [autoencoder_param['fc' + str(i + 1) + '_e.weight'].shape[0] for i in range(n_hidden)]\n",
-    "n_z = autoencoder_param['fc' + str(n_hidden + 1) + '_e.weight'].shape[0]\n",
+    "n_samples = 20\n",
+    "autoencoder.cpu()\n",
     "\n",
-    "autoencoder.load_state_dict(autoencoder_param)\n",
-    "coefs = restart_file['trainer']['best_coefs']\n",
     "gp_dictionnary = fit_gps(param_space.train_space, coefs)\n",
     "\n",
-    "n_coef = sindy.ncoefs\n",
-    "\n",
-    "from lasdi.gplasdi import sample_roms, average_rom\n",
     "Zis_samples = sample_roms(autoencoder, physics, sindy, gp_dictionnary, param_grid, n_samples)\n",
     "Zis_mean = average_rom(autoencoder, physics, sindy, gp_dictionnary, param_grid)\n",
-    "\n",
-    "print(Zis_mean.shape)\n",
-    "print(Zis_samples.shape)\n",
     "\n",
     "X_pred_mean = autoencoder.decoder(torch.Tensor(Zis_mean)).detach().numpy()\n",
     "X_pred_samples = autoencoder.decoder(torch.Tensor(Zis_samples)).detach().numpy()\n",
@@ -139,11 +221,15 @@
     "avg_rel_error = avg_rel_error.reshape([n_w_grid, n_a_grid]).T\n",
     "max_std = max_std.reshape([n_w_grid, n_a_grid]).T\n",
     "\n",
-    "print(avg_rel_error.shape)\n",
-    "print(max_std.shape)\n",
-    "\n",
-    "from lasdi.gp import eval_gp\n",
     "gp_pred_mean, gp_pred_std = eval_gp(gp_dictionnary, param_grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f31c964",
+   "metadata": {},
+   "source": [
+    "# Visualization"
    ]
   },
   {

--- a/examples/burgers1d.ipynb
+++ b/examples/burgers1d.ipynb
@@ -35,8 +35,7 @@
     "from lasdi.latent_space import Autoencoder, initial_condition_latent\n",
     "from lasdi.postprocess import compute_errors\n",
     "\n",
-    "date = '08_28_2024_20_46'\n",
-    "bglasdi_results = np.load('results/bglasdi_' + date + '.npy', allow_pickle = True).item()"
+    "filename = 'lasdi_09_11_2024_20_20.npy'"
    ]
   },
   {
@@ -55,17 +54,16 @@
    "outputs": [],
    "source": [
     "import yaml\n",
-    "from lasdi.workflow import initialize_physics, initialize_latent_space, ld_dict\n",
+    "from lasdi.workflow import initialize_trainer\n",
     "from lasdi.param import ParameterSpace\n",
     "\n",
     "cfg_file = 'burgers1d.yml'\n",
     "with open(cfg_file, 'r') as f:\n",
     "    config = yaml.safe_load(f)\n",
     "\n",
-    "param_space = ParameterSpace(config)\n",
-    "physics = initialize_physics(param_space, config)\n",
-    "autoencoder = initialize_latent_space(physics, config)\n",
-    "sindy = ld_dict[config['latent_dynamics']['type']](autoencoder.n_z, physics.nt, config['latent_dynamics'])"
+    "restart_file = np.load(filename, allow_pickle=True).item()\n",
+    "\n",
+    "trainer, param_space, physics, autoencoder, sindy = initialize_trainer(config, restart_file)"
    ]
   },
   {
@@ -75,16 +73,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "autoencoder_param = bglasdi_results['autoencoder_param']\n",
+    "from lasdi.gp import fit_gps\n",
     "\n",
-    "X_train = bglasdi_results['final_X_train']\n",
-    "coefs = bglasdi_results['coefs']\n",
-    "gp_dictionnary = bglasdi_results['gp_dictionnary']\n",
-    "fd_type = bglasdi_results['latent_dynamics']['fd_type']\n",
+    "autoencoder_param = restart_file['latent_space']['autoencoder_param']\n",
     "\n",
-    "paramspace_dict = bglasdi_results['parameters']\n",
-    "param_train = paramspace_dict['final_param_train']\n",
-    "param_grid = paramspace_dict['param_grid']\n",
+    "X_train = restart_file['trainer']['X_train']\n",
+    "\n",
+    "paramspace_dict = restart_file['parameters']\n",
+    "param_train = paramspace_dict['train_space']\n",
+    "param_grid = paramspace_dict['test_space']\n",
     "test_meshgrid = paramspace_dict['test_meshgrid']\n",
     "test_grid_sizes = paramspace_dict['test_grid_sizes']\n",
     "\n",
@@ -93,7 +90,7 @@
     "n_a_grid, n_w_grid = test_grid_sizes\n",
     "a_grid, w_grid = test_meshgrid\n",
     "\n",
-    "physics_dict = bglasdi_results['physics']\n",
+    "physics_dict = restart_file['physics']\n",
     "t_grid = physics_dict['t_grid']\n",
     "x_grid = physics_dict['x_grid']\n",
     "t_mesh, x_mesh = np.meshgrid(t_grid, x_grid)\n",
@@ -116,6 +113,9 @@
     "n_z = autoencoder_param['fc' + str(n_hidden + 1) + '_e.weight'].shape[0]\n",
     "\n",
     "autoencoder.load_state_dict(autoencoder_param)\n",
+    "Z = autoencoder.encoder(X_train)\n",
+    "coefs = sindy.calibrate(Z, physics.dt, compute_loss=False, numpy=True)\n",
+    "gp_dictionnary = fit_gps(param_space.train_space, coefs)\n",
     "\n",
     "n_coef = sindy.ncoefs\n",
     "\n",

--- a/examples/burgers1d.offline.bash
+++ b/examples/burgers1d.offline.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+# First stage will be RunSamples, which will produce parameter point files in hdf5 format.
+# Each lasdi command will save a restart file, which will be read on the next lasdi command.
+# So all stages are run by the same command, directed differently by the restart file.
+lasdi burgers1d.offline.yml
+
+# Run/save FOM solution with offline FOM solver.
+burgers1d burgers1d.offline.yml
+
+# Collect FOM solution.
+lasdi burgers1d.offline.yml
+
+# Train latent dynamics model.
+lasdi burgers1d.offline.yml
+
+for k in {0..8}
+do
+    # Pick a new sample from greedy sampling
+    lasdi burgers1d.offline.yml
+
+    # A cycle of RunSamples/offline FOM/CollectSamples
+    lasdi burgers1d.offline.yml
+    burgers1d burgers1d.offline.yml
+    lasdi burgers1d.offline.yml
+
+    # Train latent dynamics model.
+    lasdi burgers1d.offline.yml
+done

--- a/examples/burgers1d.offline.bash
+++ b/examples/burgers1d.offline.bash
@@ -1,29 +1,48 @@
 #!/usr/bin/bash
 
-# First stage will be RunSamples, which will produce parameter point files in hdf5 format.
+check_result () {
+  # $1: Result output of the previous command ($?)
+  # $2: Name of the previous command
+  if [ $1 -eq 0 ]; then
+      echo "$2 succeeded"
+  else
+      echo "$2 failed"
+      exit -1
+  fi
+}
+
+# First stage will be PickSample, which will produce parameter point files in hdf5 format.
 # Each lasdi command will save a restart file, which will be read on the next lasdi command.
 # So all stages are run by the same command, directed differently by the restart file.
 lasdi burgers1d.offline.yml
+check_result $? initial-picksample
 
 # Run/save FOM solution with offline FOM solver.
 burgers1d burgers1d.offline.yml
+check_result $? initial-runsample
 
 # Collect FOM solution.
 lasdi burgers1d.offline.yml
+check_result $? initial-collect
 
 # Train latent dynamics model.
 lasdi burgers1d.offline.yml
+check_result $? initial-train
 
 for k in {0..8}
 do
     # Pick a new sample from greedy sampling
     lasdi burgers1d.offline.yml
+    check_result $? pick-sample
 
-    # A cycle of RunSamples/offline FOM/CollectSamples
-    lasdi burgers1d.offline.yml
+    # A cycle of offline FOM/CollectSamples
     burgers1d burgers1d.offline.yml
+    check_result $? run-sample
+
     lasdi burgers1d.offline.yml
+    check_result $? collect-sample
 
     # Train latent dynamics model.
     lasdi burgers1d.offline.yml
+    check_result $? train
 done

--- a/examples/burgers1d.offline.yml
+++ b/examples/burgers1d.offline.yml
@@ -1,0 +1,61 @@
+lasdi:
+  type: gplasdi
+  gplasdi:
+    # device: mps
+    n_samples: 20
+    lr: 0.001
+    max_iter: 2000
+    n_iter: 200
+    max_greedy_iter: 2000
+    ld_weight: 0.1
+    coef_weight: 1.e-6
+    path_checkpoint: checkpoint
+    path_results: results
+
+workflow:
+  use_restart: true
+  restart_file: restarts/burgers1d.restart.npy
+  offline_greedy_sampling:
+    train_param_file: sampling/new_train.burgers1d.h5
+    test_param_file: sampling/new_test.burgers1d.h5
+    train_sol_file: sampling/new_Xtrain.burgers1d.h5
+    test_sol_file: sampling/new_Xtest.burgers1d.h5
+
+parameter_space:
+  parameters:
+    - name: a
+      min: 0.7
+      max: 0.9
+      test_space_type: uniform
+      sample_size: 11
+      log_scale: false
+    - name: w
+      min: 0.9
+      max: 1.1
+      test_space_type: uniform
+      sample_size: 11
+      log_scale: false
+  test_space:
+    type: grid
+
+latent_space:
+  type: ae
+  ae:
+    hidden_units: [100]
+    latent_dimension: 5
+
+latent_dynamics:
+  type: sindy
+  sindy:
+    fd_type: sbp12
+    coef_norm_order: fro
+
+physics:
+  type: burgers1d
+  burgers1d:
+    offline_driver: true
+    number_of_timesteps: 1001
+    simulation_time: 1.
+    grid_size: [1001]
+    xmin: -3.
+    xmax: 3.

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -12,6 +12,10 @@ lasdi:
     path_checkpoint: checkpoint
     path_results: results
 
+workflow:
+  use_restart: true
+  restart_file: restarts/burgers1d.restart.npy
+
 parameter_space:
   parameters:
     - name: a

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -7,14 +7,19 @@ lasdi:
     n_iter: 28000
     n_greedy: 2000
     max_greedy_iter: 28000
-    sindy_weight: 0.1
+    ld_weight: 0.1
     coef_weight: 1.e-6
     path_checkpoint: checkpoint
     path_results: results
 
 workflow:
-  use_restart: true
+  use_restart: false
   restart_file: restarts/burgers1d.restart.npy
+  offline_greedy_sampling:
+    train_param_file: sampling/new_train.burgers1d.h5
+    test_param_file: sampling/new_test.burgers1d.h5
+    train_sol_file: sampling/new_Xtrain.burgers1d.h5
+    test_sol_file: sampling/new_Xtest.burgers1d.h5
 
 parameter_space:
   parameters:
@@ -56,6 +61,7 @@ initial_train:
 physics:
   type: burgers1d
   burgers1d:
+    offline_driver: false
     number_of_timesteps: 1001
     simulation_time: 1.
     grid_size: [1001]

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -4,8 +4,8 @@ lasdi:
     # device: mps
     n_samples: 20
     lr: 0.001
-    n_iter: 28000
-    n_greedy: 2000
+    max_iter: 28000
+    n_iter: 2000
     max_greedy_iter: 28000
     ld_weight: 0.1
     coef_weight: 1.e-6
@@ -52,11 +52,6 @@ latent_dynamics:
   sindy:
     fd_type: sbp12
     coef_norm_order: fro
-
-# TODO(kevin): temporary placeholder
-initial_train:
-  train_data: data/data_train.npy
-  test_data: data/data_test.npy
 
 physics:
   type: burgers1d

--- a/examples/template_training.ipynb
+++ b/examples/template_training.ipynb
@@ -1,0 +1,510 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d31d3171",
+   "metadata": {},
+   "source": [
+    "# Template for autoencoder prototyping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d67dad03-9d76-4891-82ff-7e19d1369a24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import numpy as np\n",
+    "from matplotlib.colors import LinearSegmentedColormap\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.animation as animation\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Name for the case\n",
+    "name = 'template'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fceceb92",
+   "metadata": {},
+   "source": [
+    "## Hyper-parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b05f7c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = 1.0e-5\n",
+    "ae_weight = 1e0\n",
+    "sindy_weight = 1.e-6\n",
+    "coef_weight= 1.e-9\n",
+    "lr = 1e-5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55bc1410",
+   "metadata": {},
+   "source": [
+    "## Training data\n",
+    "\n",
+    "- Consider we only have one time-series simulation.\n",
+    "- suppose we have grid of size (20x30) points.\n",
+    "- solution is a 2-dimensional vector (on each grid point)\n",
+    "- A simulation of 50 time steps.\n",
+    "- the first index of snapshot array should be timestep.\n",
+    "- we consider dof as solution dimension, and number of particles as grid size.\n",
+    "\n",
+    "Can load other data files for your custom autoencoder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca3062c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ntrain = 1\n",
+    "sol_dim = 2\n",
+    "grid_dim = [20,30]\n",
+    "nt = 50\n",
+    "\n",
+    "# number of cases x number of time step x solution dimension x grid size\n",
+    "snapshots = np.random.rand(ntrain, nt, sol_dim, grid_dim[0], grid_dim[1])\n",
+    "X_train = torch.Tensor(snapshots)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b6241c5",
+   "metadata": {},
+   "source": [
+    "## Setting up a physics wrapper.\n",
+    "\n",
+    "You can choose from `lasdi.physics` module, or create a custom physics model. Following snippet is an example with some necessary specifications."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a0349ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.physics import Physics\n",
+    "\n",
+    "class CustomPhysicsModel(Physics):\n",
+    "    def __init__(self):\n",
+    "        self.dim = 2\n",
+    "        self.nt = nt\n",
+    "        self.dt = dt\n",
+    "        self.qdim = sol_dim\n",
+    "        self.grid_size = grid_dim\n",
+    "        self.qgrid_size = [sol_dim] + grid_dim\n",
+    "\n",
+    "        ''' Set up a grid as you see fit. '''\n",
+    "        self.x_grid = np.zeros([self.dim] + self.grid_size)\n",
+    "        xg = np.linspace(0., 1., grid_dim[1])\n",
+    "        yg = np.linspace(0., 1., grid_dim[0])\n",
+    "        self.x_grid[0], self.x_grid[1] = np.meshgrid(xg, yg)\n",
+    "        return\n",
+    "    \n",
+    "    ''' See lasdi.physics.Physics class for necessary subroutines '''\n",
+    "\n",
+    "physics = CustomPhysicsModel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9996b792",
+   "metadata": {},
+   "source": [
+    "## Setting up autoencoder\n",
+    "\n",
+    "You can choose from `lasdi.latent_space` module, or create a custom autoencoder. The snippet below uses a built-in `Autoencoder` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c53127b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.latent_space import Autoencoder\n",
+    "\n",
+    "n_train = 1\n",
+    "hidden_units = [3000, 300, 300, 100, 100, 30]\n",
+    "# latent space dimension\n",
+    "n_z = 5\n",
+    "print(physics.grid_size, hidden_units, n_z)\n",
+    "\n",
+    "# I think these options are straightforward.\n",
+    "ae_cfg = {'hidden_units': hidden_units, 'latent_dimension': n_z, 'activation': 'softplus'}\n",
+    "\n",
+    "ae = Autoencoder(physics, ae_cfg)\n",
+    "best_loss = np.Inf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0ea7a53",
+   "metadata": {},
+   "source": [
+    "## Setting up latent dynamics\n",
+    "\n",
+    "Similarly, we either choose a latent dynamics model from `lasdi.latent_dynamics` module or create a custom model. Here we use `SINDy` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad4ae3ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.latent_dynamics.sindy import SINDy\n",
+    "\n",
+    "sindy_options = {'sindy': {'fd_type': 'sbp12'}} # finite-difference operator for computing time derivative of latent trajectory.\n",
+    "ld = SINDy(ae.n_z, physics.nt, sindy_options)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5d98899",
+   "metadata": {},
+   "source": [
+    "## Training: (1) Running a custom optimization process"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36bacfa9",
+   "metadata": {},
+   "source": [
+    "Set up optimizer and loss term"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31de72b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer = torch.optim.Adam(ae.parameters(), lr = lr)\n",
+    "MSE = torch.nn.MSELoss()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55cfb184",
+   "metadata": {},
+   "source": [
+    "Set up device: `'cuda'`, `'mps'` (apple) or `'cpu'`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35cd5db2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = 'cpu'\n",
+    "d_ae = ae.to(device)\n",
+    "d_Xtrain = X_train.to(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65bc550a",
+   "metadata": {},
+   "source": [
+    "This is a part of GPLaSDI training procedure, where the training is executed without on-the-fly sampling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff367763",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_iter = 10\n",
+    "save_interval = 1\n",
+    "hist_file = '%s.loss_history.txt' % name\n",
+    "\n",
+    "loss_hist = np.zeros([n_iter, 4])\n",
+    "grad_hist = np.zeros([n_iter, 4])\n",
+    "for iter in range(n_iter):\n",
+    "    optimizer.zero_grad()\n",
+    "    d_ae = ae.to(device)\n",
+    "    d_Z = d_ae.encoder(d_Xtrain)\n",
+    "    d_Xpred = d_ae.decoder(d_Z)\n",
+    "    Z = d_Z.cpu()\n",
+    "\n",
+    "    loss_ae = MSE(d_Xtrain, d_Xpred)\n",
+    "    coefs, loss_sindy, loss_coef = ld.calibrate(Z, physics.dt, compute_loss=True, numpy=True)\n",
+    "\n",
+    "    max_coef = np.abs(np.array(coefs)).max()\n",
+    "    loss = ae_weight * loss_ae + sindy_weight * loss_sindy / n_train + coef_weight * loss_coef / n_train\n",
+    "\n",
+    "    loss_hist[iter] = [loss.item(), loss_ae.item(), loss_sindy.item(), loss_coef.item()]\n",
+    "\n",
+    "    loss.backward()\n",
+    "\n",
+    "    optimizer.step()\n",
+    "\n",
+    "    if ((loss.item() < best_loss) and (iter % save_interval == 0)):\n",
+    "        torch.save(d_ae.cpu().state_dict(), './%s_checkpoint.pt' % name)\n",
+    "        best_loss = loss.item()\n",
+    "\n",
+    "    # print(\"Iter: %05d/%d, Loss: %.5e\" % (iter + 1, n_iter, loss.item()))\n",
+    "    print(\"Iter: %05d/%d, Loss: %.5e, Loss AE: %.5e, Loss SI: %.5e, Loss COEF: %.5e, max|c|: %.5e\"\n",
+    "            % (iter + 1, n_iter, loss.item(), loss_ae.item(), loss_sindy.item(), loss_coef.item(), max_coef))\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "015d02f5",
+   "metadata": {},
+   "source": [
+    "Save the history and the trained parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb293bb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.savetxt('%s.loss_history.txt' % name, loss_hist)\n",
+    "\n",
+    "if (loss.item() < best_loss):\n",
+    "    torch.save(d_ae.cpu().state_dict(), './%s_checkpoint.pt' % name)\n",
+    "    best_loss = loss.item()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97f719d3",
+   "metadata": {},
+   "source": [
+    "Load a checkpoint and re-evaluate the losses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00f7da25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state_dict = torch.load('%s_checkpoint.pt' % name)\n",
+    "ae.load_state_dict(state_dict)\n",
+    "ae.eval()\n",
+    "d_ae = ae.to(device)\n",
+    "d_Z = d_ae.encoder(d_Xtrain)\n",
+    "d_Xpred = d_ae.decoder(d_Z)\n",
+    "Z = d_Z.cpu()\n",
+    "print(Z.shape)\n",
+    "\n",
+    "loss_ae = MSE(d_Xtrain, d_Xpred)\n",
+    "coefs, loss_sindy, loss_coef = ld.calibrate(Z, physics.dt, compute_loss=True, numpy=True)\n",
+    "\n",
+    "max_coef = np.abs(np.array(coefs)).max()\n",
+    "loss = loss_ae + sindy_weight * loss_sindy / n_train + coef_weight * loss_coef / n_train\n",
+    "print(loss.item())\n",
+    "print(loss_ae.item())\n",
+    "print((sindy_weight * loss_sindy / n_train).item())\n",
+    "print((coef_weight * loss_coef / n_train).item())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6516cfa7",
+   "metadata": {},
+   "source": [
+    "Visualize the loss history"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d62570fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss_hist = np.loadtxt('%s.loss_history.txt' % name)\n",
+    "\n",
+    "plt.figure(1)\n",
+    "plt.loglog(loss_hist[:, 0])\n",
+    "plt.xlabel('iteration')\n",
+    "plt.ylabel('loss')\n",
+    "\n",
+    "plt.rcParams.update({'font.size': 15})\n",
+    "plt.figure(2, figsize=(8, 6))\n",
+    "plt.loglog(loss_hist[:, 1:])\n",
+    "plt.xlabel('iteration')\n",
+    "plt.ylabel('loss')\n",
+    "plt.legend([\"ae\", \"sindy\", \"coef\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82af6aa5",
+   "metadata": {},
+   "source": [
+    "Obtain the predicted solution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4692510d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tgrid = np.linspace(0, (nt-1)*dt, nt)\n",
+    "\n",
+    "d_Z = d_ae.encoder(d_Xtrain)\n",
+    "Z = d_Z.cpu().detach().numpy()\n",
+    "\n",
+    "Zpred = np.zeros([n_train, physics.nt, ae.n_z])\n",
+    "for case_idx in range(len(coefs)):\n",
+    "    Zpred[case_idx] = ld.simulate(coefs[case_idx], Z[case_idx, 0], tgrid)\n",
+    "\n",
+    "d_Zpred = torch.Tensor(Zpred).to(device)\n",
+    "X_pred = d_ae.decoder(d_Zpred).cpu().detach().numpy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38cafdda",
+   "metadata": {},
+   "source": [
+    "Plot the latent variable evolution and compare the prediction with the truth"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f178a53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colors = ['r','g','b','c','m']\n",
+    "\n",
+    "for case_idx in range(len(coefs)):\n",
+    "    plt.figure(1+case_idx, figsize=(8,6))\n",
+    "    for k, color in enumerate(colors):\n",
+    "        plt.plot(Zpred[case_idx][:, k],'-'+color)\n",
+    "        plt.plot(Z[case_idx][:, k],'--'+color)\n",
+    "    plt.ylabel('$Z$')\n",
+    "    plt.xlabel('$t$ ($\\\\times\\Delta t$)')\n",
+    "    plt.legend(['pred','truth'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfb4c0bf",
+   "metadata": {},
+   "source": [
+    "Visualization of full-order model solution.\n",
+    "Feel free to change as you see fit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da08d933",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "case_idx = 0\n",
+    "time_idx = 14\n",
+    "var_idx = 0\n",
+    "\n",
+    "truth = snapshots[case_idx, time_idx, var_idx]\n",
+    "pred = X_pred[case_idx, time_idx, var_idx]\n",
+    "\n",
+    "plt.figure(1)\n",
+    "plt.contourf(physics.x_grid[0], physics.x_grid[1], truth, 200)\n",
+    "\n",
+    "plt.figure(2)\n",
+    "plt.contourf(physics.x_grid[0], physics.x_grid[1], pred, 200)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71653612",
+   "metadata": {},
+   "source": [
+    "## Training: (2) Using built-in GPLaSDI trainer\n",
+    "\n",
+    "**Work in progress**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ad84e16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lasdi.gplasdi import BayesianGLaSDI\n",
+    "\n",
+    "trainer_options = {'n_samples': 20,         # number of samples when choosing a new parameter point. Not used in this case\n",
+    "                   'lr': lr,                # learning rate\n",
+    "                   'n_iter': 10000,         # number of iteration in training\n",
+    "                   'max_greedy_iter': 0,    # maximum iteration to perform greedy sampling. Not used in this case\n",
+    "                   'n_greedy': -1,          # frequency of greedy sampling. Not used in this case\n",
+    "                   'sindy_weight': sindy_weight, # weight for latent dynamics loss\n",
+    "                   'coef_weight': coef_weight,   # weight for latent dynamics coefficient regularization\n",
+    "                   'device': 'cpu',              # device to perform training (cpu, cuda, mps)\n",
+    "                   'path_checkpoint': 'checkpoints', # directory to save training checkpoint files\n",
+    "                   'path_results': 'results',        # directory to save training results\n",
+    "                   }\n",
+    "\n",
+    "trainer = BayesianGLaSDI(physics, ae, ld, trainer_options)\n",
+    "trainer.X_train = X_train\n",
+    "\n",
+    "trainer.train()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv_gpu",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
   "scipy>=1.10",
   "pyyaml>=6.0",
   "matplotlib>=3.8.0",
-  "argparse>=1.1"
+  "argparse>=1.1",
+  "h5py"
 ]
 
 [project.urls]
@@ -34,3 +35,4 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 lasdi = "lasdi.workflow:main [config_file]"
+burgers1d = "lasdi.physics.burgers1d:main [config_file]"

--- a/src/lasdi/enums.py
+++ b/src/lasdi/enums.py
@@ -1,8 +1,8 @@
 from enum import Enum
 
 class NextStep(Enum):
-    Initial = 1
-    Train = 2
+    Train = 1
+    PickSample = 2
     RunSample = 3
     CollectSample = 4
 

--- a/src/lasdi/gplasdi.py
+++ b/src/lasdi/gplasdi.py
@@ -138,7 +138,7 @@ class BayesianGLaSDI:
         else:
             self.device = 'cpu'
 
-        self.best_loss = np.Inf
+        self.best_loss = np.inf
         self.best_coefs = None
         self.restart_iter = 0
 

--- a/src/lasdi/gplasdi.py
+++ b/src/lasdi/gplasdi.py
@@ -92,7 +92,7 @@ class BayesianGLaSDI:
     X_train = torch.Tensor([])
     X_test = torch.Tensor([])
 
-    def __init__(self, physics, autoencoder, latent_dynamics, config):
+    def __init__(self, physics, autoencoder, latent_dynamics, param_space, config):
 
         '''
 
@@ -106,7 +106,7 @@ class BayesianGLaSDI:
         self.autoencoder = autoencoder
         self.latent_dynamics = latent_dynamics
         self.physics = physics
-        self.param_space = physics.param_space
+        self.param_space = param_space
         self.timer = Timer()
 
         self.n_samples = config['n_samples']

--- a/src/lasdi/gplasdi.py
+++ b/src/lasdi/gplasdi.py
@@ -257,7 +257,7 @@ class BayesianGLaSDI:
 
         m_index = get_fom_max_std(ae, Zis)
 
-        new_sample = ps.test_space[m_index, :]
+        new_sample = ps.test_space[m_index, :].reshape(1, -1)
         print('New param: ' + str(np.round(new_sample, 4)) + '\n')
 
         self.timer.end("new_sample")

--- a/src/lasdi/inputs.py
+++ b/src/lasdi/inputs.py
@@ -47,7 +47,7 @@ def getDictFromList(list_, inputDict):
     '''
         get a dict with {key: val} from a list of dicts
         NOTE: it returns only the first item in the list,
-            even if the list has more than one dict with {key: val}.
+        even if the list has more than one dict with {key: val}.
     '''
     dict_ = None
     for item in list_:

--- a/src/lasdi/latent_dynamics/__init__.py
+++ b/src/lasdi/latent_dynamics/__init__.py
@@ -57,3 +57,10 @@ class LatentDynamics:
         param_dict = {'dim': self.dim, 'ncoefs': self.ncoefs}
         return param_dict
     
+    # SINDy does not need to load parameters.
+    # Other latent dynamics might need to.
+    def load(self, dict_):
+        assert(self.dim == dict_['dim'])
+        assert(self.ncoefs == dict_['ncoefs'])
+        return
+    

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -15,7 +15,6 @@ def initial_condition_latent(param_grid, physics, autoencoder):
     sol_shape = [1, 1] + physics.qgrid_size
 
     for i in range(n_param):
-        # TODO(kevin): generalize parameter class.
         u0 = physics.initial_condition(param_grid[i])
         u0 = u0.reshape(sol_shape)
         u0 = torch.Tensor(u0)

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -66,6 +66,7 @@ class MultiLayerPerceptron(torch.nn.Module):
         for k in range(self.n_layers-1):
             self.fcs += [torch.nn.Linear(layer_sizes[k], layer_sizes[k + 1])]
         self.fcs = torch.nn.ModuleList(self.fcs)
+        self.init_weight()
 
         # Reshape input or output layer
         assert((reshape_index is None) or (reshape_index in [0, -1]))

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -175,3 +175,11 @@ class Autoencoder(torch.nn.Module):
         x = x.squeeze(1)  # Remove sequence dimension
         
         return x
+    
+    def export(self):
+        dict_ = {'autoencoder_param': self.cpu().state_dict()}
+        return dict_
+    
+    def load(self, dict_):
+        self.load_state_dict(dict_['autoencoder_param'])
+        return

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -1,6 +1,32 @@
 import torch
 import numpy as np
 
+# activation dict
+act_dict = {'ELU': torch.nn.ELU,
+            'hardshrink': torch.nn.Hardshrink,
+            'hardsigmoid': torch.nn.Hardsigmoid,
+            'hardtanh': torch.nn.Hardtanh,
+            'hardswish': torch.nn.Hardswish,
+            'leakyReLU': torch.nn.LeakyReLU,
+            'logsigmoid': torch.nn.LogSigmoid,
+            'multihead': torch.nn.MultiheadAttention,
+            'PReLU': torch.nn.PReLU,
+            'ReLU': torch.nn.ReLU,
+            'ReLU6': torch.nn.ReLU6,
+            'RReLU': torch.nn.RReLU,
+            'SELU': torch.nn.SELU,
+            'CELU': torch.nn.CELU,
+            'GELU': torch.nn.GELU,
+            'sigmoid': torch.nn.Sigmoid,
+            'SiLU': torch.nn.SiLU,
+            'mish': torch.nn.Mish,
+            'softplus': torch.nn.Softplus,
+            'softshrink': torch.nn.Softshrink,
+            'tanh': torch.nn.Tanh,
+            'tanhshrink': torch.nn.Tanhshrink,
+            'threshold': torch.nn.Threshold,
+            }
+
 def initial_condition_latent(param_grid, physics, autoencoder):
 
     '''
@@ -23,39 +49,88 @@ def initial_condition_latent(param_grid, physics, autoencoder):
         Z0.append(z0)
 
     return Z0
-    
-class Autoencoder(torch.nn.Module):
-    # set by physics.qgrid_size
-    qgrid_size = []
-    # prod(qgrid_size)
-    space_dim = -1
-    n_z = -1
 
-    # activation dict
-    act_dict = {'ELU': torch.nn.ELU,
-                'hardshrink': torch.nn.Hardshrink,
-                'hardsigmoid': torch.nn.Hardsigmoid,
-                'hardtanh': torch.nn.Hardtanh,
-                'hardswish': torch.nn.Hardswish,
-                'leakyReLU': torch.nn.LeakyReLU,
-                'logsigmoid': torch.nn.LogSigmoid,
-                'multihead': torch.nn.MultiheadAttention,
-                'PReLU': torch.nn.PReLU,
-                'ReLU': torch.nn.ReLU,
-                'ReLU6': torch.nn.ReLU6,
-                'RReLU': torch.nn.RReLU,
-                'SELU': torch.nn.SELU,
-                'CELU': torch.nn.CELU,
-                'GELU': torch.nn.GELU,
-                'sigmoid': torch.nn.Sigmoid,
-                'SiLU': torch.nn.SiLU,
-                'mish': torch.nn.Mish,
-                'softplus': torch.nn.Softplus,
-                'softshrink': torch.nn.Softshrink,
-                'tanh': torch.nn.Tanh,
-                'tanhshrink': torch.nn.Tanhshrink,
-                'threshold': torch.nn.Threshold,
-                }
+class MultiLayerPerceptron(torch.nn.Module):
+
+    def __init__(self, layer_sizes,
+                 act_type='sigmoid', reshape_index=None, reshape_shape=None,
+                 threshold=0.1, value=0.0, num_heads=1):
+        super(MultiLayerPerceptron, self).__init__()
+
+        # including input, hidden, output layers
+        self.n_layers = len(layer_sizes)
+        self.layer_sizes = layer_sizes
+
+        # Linear features between layers
+        self.fcs = []
+        for k in range(self.n_layers-1):
+            self.fcs += [torch.nn.Linear(layer_sizes[k], layer_sizes[k + 1])]
+        self.fcs = torch.nn.ModuleList(self.fcs)
+
+        # Reshape input or output layer
+        assert((reshape_index is None) or (reshape_index in [0, -1]))
+        assert((reshape_shape is None) or (np.prod(reshape_shape) == layer_sizes[reshape_index]))
+        self.reshape_index = reshape_index
+        self.reshape_shape = reshape_shape
+
+        # Initalize activation function
+        self.act_type = act_type
+        self.use_multihead = False
+        if act_type == "threshold":
+            self.act = act_dict[act_type](threshold, value)
+
+        elif act_type == "multihead":
+            self.use_multihead = True
+            if (self.n_layers > 3): # if you have more than one hidden layer
+                self.act = []
+                for i in range(self.n_layers-2):
+                    self.act += [act_dict[act_type](layer_sizes[i+1], num_heads)]
+            else:
+                self.act = [torch.nn.Identity()]  # No additional activation
+            self.act = torch.nn.ModuleList(self.fcs)
+
+        #all other activation functions initialized here
+        else:
+            self.act = act_dict[act_type]()
+        return
+    
+    def forward(self, x):
+        if (self.reshape_index == 0):
+            # make sure the input has a proper shape
+            assert(list(x.shape[-len(self.reshape_shape):]) == self.reshape_shape)
+            # we use torch.Tensor.view instead of torch.Tensor.reshape,
+            # in order to avoid data copying.
+            x = x.view(list(x.shape[:-len(self.reshape_shape)]) + [self.layer_sizes[self.reshape_index]])
+
+        for i in range(self.n_layers-2):
+            x = self.fcs[i](x) # apply linear layer
+            if (self.use_multihead):
+                x = self.apply_attention(self, x, i)
+            else:
+                x = self.act(x)
+
+        x = self.fcs[-1](x)
+
+        if (self.reshape_index == -1):
+            # we use torch.Tensor.view instead of torch.Tensor.reshape,
+            # in order to avoid data copying.
+            x = x.view(list(x.shape[:-1]) + self.reshape_shape)
+
+        return x
+    
+    def apply_attention(self, x, act_idx):
+        x = x.unsqueeze(1)  # Add sequence dimension for attention
+        x, _ = self.act[act_idx](x, x, x) # apply attention
+        x = x.squeeze(1)  # Remove sequence dimension
+        return x
+    
+    def init_weight(self):
+        # TODO(kevin): support other initializations?
+        for fc in self.fcs:
+            torch.nn.init.xavier_uniform_(fc.weight)
+        return
+
+class Autoencoder(torch.nn.Module):
 
     def __init__(self, physics, config):
         super(Autoencoder, self).__init__()
@@ -66,113 +141,28 @@ class Autoencoder(torch.nn.Module):
         n_z = config['latent_dimension']
         self.n_z = n_z
 
-        n_layers = len(hidden_units)
-        self.n_layers = n_layers
-
-        fc1_e = torch.nn.Linear(self.space_dim, hidden_units[0])
-        torch.nn.init.xavier_uniform_(fc1_e.weight)
-        self.fc1_e = fc1_e
-
-        if n_layers > 1:
-            for i in range(n_layers - 1):
-                fc_e = torch.nn.Linear(hidden_units[i], hidden_units[i + 1])
-                torch.nn.init.xavier_uniform_(fc_e.weight)
-                setattr(self, 'fc' + str(i + 2) + '_e', fc_e)
-
-        fc_e = torch.nn.Linear(hidden_units[-1], n_z)
-        torch.nn.init.xavier_uniform_(fc_e.weight)
-        setattr(self, 'fc' + str(n_layers + 1) + '_e', fc_e)
-
+        layer_sizes = [self.space_dim] + hidden_units + [n_z]
+        #grab relevant initialization values from config
         act_type = config['activation'] if 'activation' in config else 'sigmoid'
-        if act_type == "threshold":
-            #grab relevant initialization values from config
-            threshold = config["threshold"] if "threshold" in config else 0.1
-            value = config["value"] if "value" in config else 0.0
-            self.g_e = self.act_dict[act_type](threshold, value)
+        threshold = config["threshold"] if "threshold" in config else 0.1
+        value = config["value"] if "value" in config else 0.0
+        num_heads = config['num_heads'] if 'num_heads' in config else 1
 
-        elif act_type == "multihead":
-            #grab relevant initialization values from config
-            num_heads = config['num_heads'] if 'num_heads' in config else 1
-            if n_layers > 1:
-                for i in range(n_layers):
-                    setattr(self, 'a' + str(i + 1), self.act_dict[act_type](hidden_units[i], num_heads))
-            self.g_e = torch.nn.Identity()  # No additional activation
+        self.encoder = MultiLayerPerceptron(layer_sizes, act_type,
+                                            reshape_index=0, reshape_shape=self.qgrid_size,
+                                            threshold=threshold, value=value, num_heads=num_heads)
+        
+        self.decoder = MultiLayerPerceptron(layer_sizes[::-1], act_type,
+                                            reshape_index=-1, reshape_shape=self.qgrid_size,
+                                            threshold=threshold, value=value, num_heads=num_heads)
 
-        #all other activation functions initialized here
-        else:
-            self.g_e = self.act_dict[act_type]()
-
-        fc1_d = torch.nn.Linear(n_z, hidden_units[-1])
-        torch.nn.init.xavier_uniform_(fc1_d.weight)
-        self.fc1_d = fc1_d
-
-        if n_layers > 1:
-            for i in range(n_layers - 1, 0, -1):
-                fc_d = torch.nn.Linear(hidden_units[i], hidden_units[i - 1])
-                torch.nn.init.xavier_uniform_(fc_d.weight)
-                setattr(self, 'fc' + str(n_layers - i + 1) + '_d', fc_d)
-
-        fc_d = torch.nn.Linear(hidden_units[0], self.space_dim)
-        torch.nn.init.xavier_uniform_(fc_d.weight)
-        setattr(self, 'fc' + str(n_layers + 1) + '_d', fc_d)
-
-
-
-    def encoder(self, x):
-        # make sure the input has a proper shape
-        assert(list(x.shape[-len(self.qgrid_size):]) == self.qgrid_size)
-        # we use torch.Tensor.view instead of torch.Tensor.reshape,
-        # in order to avoid data copying.
-        x = x.view(list(x.shape[:-len(self.qgrid_size)]) + [self.space_dim])
-
-        for i in range(1, self.n_layers + 1):
-            fc = getattr(self, 'fc' + str(i) + '_e')
-            x = fc(x) # apply linear layer
-            if hasattr(self, 'a1'): # test if there is at least one attention layer
-                x = self.apply_attention(self, x, i)
-                
-            x = self.g_e(x) # apply activation function
-
-        fc = getattr(self, 'fc' + str(self.n_layers + 1) + '_e')
-        x = fc(x)
-
-        return x
-
-
-    def decoder(self, x):
-
-        for i in range(1, self.n_layers + 1):
-            fc = getattr(self, 'fc' + str(i) + '_d')
-            x = fc(x) # apply linear layer
-            if hasattr(self, 'a1'): # test if there is at least one attention layer
-                x = self.apply_attention(self, x, self.n_layers - i)
-
-            x = self.g_e(x) # apply activation function
-
-        fc = getattr(self, 'fc' + str(self.n_layers + 1) + '_d')
-        x = fc(x)
-
-        # we use torch.Tensor.view instead of torch.Tensor.reshape,
-        # in order to avoid data copying.
-        x = x.view(list(x.shape[:-1]) + self.qgrid_size)
-
-        return x
-
+        return
 
     def forward(self, x):
 
         x = self.encoder(x)
         x = self.decoder(x)
 
-        return x
-
-
-    def apply_attention(self, x, layer):
-        x = x.unsqueeze(1)  # Add sequence dimension for attention
-        a = getattr(self, 'a' + str(layer))
-        x, _ = a(x, x, x) # apply attention
-        x = x.squeeze(1)  # Remove sequence dimension
-        
         return x
     
     def export(self):

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -1,146 +1,323 @@
-import torch
-import numpy as np
+# -------------------------------------------------------------------------------------------------
+# Imports and setup
+# -------------------------------------------------------------------------------------------------
+
+import  torch
+import  numpy       as      np
+
+from   .physics     import  Physics
 
 # activation dict
-act_dict = {'ELU': torch.nn.ELU,
-            'hardshrink': torch.nn.Hardshrink,
-            'hardsigmoid': torch.nn.Hardsigmoid,
-            'hardtanh': torch.nn.Hardtanh,
-            'hardswish': torch.nn.Hardswish,
-            'leakyReLU': torch.nn.LeakyReLU,
-            'logsigmoid': torch.nn.LogSigmoid,
-            'multihead': torch.nn.MultiheadAttention,
-            'PReLU': torch.nn.PReLU,
-            'ReLU': torch.nn.ReLU,
-            'ReLU6': torch.nn.ReLU6,
-            'RReLU': torch.nn.RReLU,
-            'SELU': torch.nn.SELU,
-            'CELU': torch.nn.CELU,
-            'GELU': torch.nn.GELU,
-            'sigmoid': torch.nn.Sigmoid,
-            'SiLU': torch.nn.SiLU,
-            'mish': torch.nn.Mish,
-            'softplus': torch.nn.Softplus,
-            'softshrink': torch.nn.Softshrink,
-            'tanh': torch.nn.Tanh,
-            'tanhshrink': torch.nn.Tanhshrink,
-            'threshold': torch.nn.Threshold,
-            }
+act_dict = {'ELU'           : torch.nn.ELU,
+            'hardshrink'    : torch.nn.Hardshrink,
+            'hardsigmoid'   : torch.nn.Hardsigmoid,
+            'hardtanh'      : torch.nn.Hardtanh,
+            'hardswish'     : torch.nn.Hardswish,
+            'leakyReLU'     : torch.nn.LeakyReLU,
+            'logsigmoid'    : torch.nn.LogSigmoid,
+            'PReLU'         : torch.nn.PReLU,
+            'ReLU'          : torch.nn.ReLU,
+            'ReLU6'         : torch.nn.ReLU6,
+            'RReLU'         : torch.nn.RReLU,
+            'SELU'          : torch.nn.SELU,
+            'CELU'          : torch.nn.CELU,
+            'GELU'          : torch.nn.GELU,
+            'sigmoid'       : torch.nn.Sigmoid,
+            'SiLU'          : torch.nn.SiLU,
+            'mish'          : torch.nn.Mish,
+            'softplus'      : torch.nn.Softplus,
+            'softshrink'    : torch.nn.Softshrink,
+            'tanh'          : torch.nn.Tanh,
+            'tanhshrink'    : torch.nn.Tanhshrink,
+            'threshold'     : torch.nn.Threshold,}
 
-def initial_condition_latent(param_grid, physics, autoencoder):
 
-    '''
 
-    Outputs the initial condition in the latent space: Z0 = encoder(U0)
+# -------------------------------------------------------------------------------------------------
+# initial_conditions_latent function
+# -------------------------------------------------------------------------------------------------
 
-    '''
+def initial_condition_latent(param_grid     : np.ndarray, 
+                             physics        : Physics, 
+                             autoencoder    : torch.nn.Module) -> list[np.ndarray]:
+    """
+    This function maps a set of initial conditions for the fom to initial conditions for the 
+    latent space dynamics. Specifically, we take in a set of possible parameter values. For each 
+    set of parameter values, we recover the fom IC (from physics), then map this fom IC to a 
+    latent space IC (by encoding it using the autoencoder). We do this for each parameter 
+    combination and then return a list housing the latent space ICs.
 
-    n_param = param_grid.shape[0]
-    Z0 = []
+    
+    -----------------------------------------------------------------------------------------------
+    Arguments
+    -----------------------------------------------------------------------------------------------
 
-    sol_shape = [1, 1] + physics.qgrid_size
+    param_grid: A 2d numpy.ndarray object of shape (number of parameter combination) x (number of 
+    parameters).
 
+    physics: A "Physics" object that stores the datasets for each parameter combination. 
+
+    autoencoder: The actual autoencoder object that we use to map the ICs into the latent space.
+
+
+    -----------------------------------------------------------------------------------------------
+    Returns
+    -----------------------------------------------------------------------------------------------
+    
+    A list of numpy ndarray objects whose i'th element holds the latent space initial condition 
+    for the i'th set of parameters in the param_grid. That is, if we let U0_i denote the fom IC for 
+    the i'th set of parameters, then the i'th element of the returned list is Z0_i = encoder(U0_i).
+    """
+
+    # Figure out how many parameters we are testing at. 
+    n_param     : int               = param_grid.shape[0]
+    Z0          : list[np.ndarray]  = []
+    sol_shape   : list[int]         = [1, 1] + physics.qgrid_size
+    
+    # Cycle through the parameters.
     for i in range(n_param):
-        u0 = physics.initial_condition(param_grid[i])
+        # TODO(kevin): generalize parameter class.
+
+        # Fetch the IC for the i'th set of parameters. Then map it to a tensor.
+        u0 : np.ndarray = physics.initial_condition(param_grid[i])
         u0 = u0.reshape(sol_shape)
         u0 = torch.Tensor(u0)
+
+        # Encode the IC, then map the encoding to a numpy array.
         z0 = autoencoder.encoder(u0)
         z0 = z0[0, 0, :].detach().numpy()
+
+        # Append the new IC to the list of latent ICs
         Z0.append(z0)
 
+    # Return the list of latent ICs.
     return Z0
 
+
+
+# -------------------------------------------------------------------------------------------------
+# MLP class
+# -------------------------------------------------------------------------------------------------
+
 class MultiLayerPerceptron(torch.nn.Module):
+    def __init__(   self, 
+                    layer_sizes     : list[int],
+                    act_type        : str           = 'sigmoid',
+                    reshape_index   : int           = None, 
+                    reshape_shape   : tuple[int]    = None,
+                    threshold       : float         = 0.1, 
+                    value           : float         = 0.0) -> None:
+        """
+        This class defines a standard multi-layer network network.
 
-    def __init__(self, layer_sizes,
-                 act_type='sigmoid', reshape_index=None, reshape_shape=None,
-                 threshold=0.1, value=0.0, num_heads=1):
-        super(MultiLayerPerceptron, self).__init__()
 
-        # including input, hidden, output layers
-        self.n_layers = len(layer_sizes)
-        self.layer_sizes = layer_sizes
 
-        # Linear features between layers
-        self.fcs = []
-        for k in range(self.n_layers-1):
-            self.fcs += [torch.nn.Linear(layer_sizes[k], layer_sizes[k + 1])]
-        self.fcs = torch.nn.ModuleList(self.fcs)
-        self.init_weight()
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
 
-        # Reshape input or output layer
+        layer_sizes: A list of integers specifying the widths of the layers (including the 
+        dimensionality of the domain of each layer, as well as the co-domain of the final layer).
+        Suppose this list has N elements. Then the network will have N - 1 layers. The i'th layer 
+        maps from \mathbb{R}^{layer_sizes[i]} to \mathbb{R}^{layers_sizes[i]}. Thus, the i'th 
+        element of this list represents the domain of the i'th layer AND the co-domain of the 
+        i-1'th layer.
+
+        act_type: A string specifying which activation function we want to use at the end of each 
+        layer (except the final one). We use the same activation for each layer. 
+
+        reshape_index: This argument specifies if we should reshape the network's input or output 
+        (or neither). If the user specifies reshape_index, then it must be either 0 or -1. Further, 
+        in this case, they must also specify reshape_shape (you need to specify both together). If
+        it is 0, then reshape_shape specifies how we reshape the input before passing it through 
+        the network (the input to the first layer). If reshape_index is -1, then reshape_shape 
+        specifies how we reshape the network output before returning it (the output to the last 
+        layer). 
+
+        reshape_shape: These are lists of k integers specifying the final k dimensions of the shape
+        of the input to the first layer (if reshape_index == 0) or the output of the last layer 
+        (if reshape_index == -1). You must specify this argument if and only if you specify 
+        reshape_index. 
+
+        threshold: You should only specify this argument if you are using the "Threshold" 
+        activation type. In this case, it specifies the threshold value for that activation (if x
+        is the input and x > threshold, then the function returns x. Otherwise, it returns the 
+        value).
+
+        value: You should only specify this argument if you are using the "Threshold" activation
+        type. In this case, "value" specifies the value that the function returns if the input is
+        below the threshold. 
+
+
+
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+        
+        Nothing!
+        """
+
+        # Run checks.
+        # Make sure the reshape index is either 0 (input to 1st layer) or -1 (output of last 
+        # layer). Also make sure that that product of the dimensions in the reshape_shape match
+        # the input dimension for the 1st layer (if reshape_index == 0) or the output dimension of
+        # the last layer (if reshape_index == 1). 
+        # 
+        # Why do we need the later condition? Well, suppose that reshape_shape has a length of k. 
+        # If reshape_index == 0, then we squeeze the final k dimensions of the input and feed that 
+        # into the first layer. Thus, in this case, we need the last dimension of the squeezed 
+        # array to match the input domain of the first layer. On the other hand, reshape_index == -1 
+        # then we reshape the final dimension of the output to match the reshape_shape. Thus, in 
+        # both cases, we need the product of the components of reshape_shape to match a 
+        # corresponding element of layer_sizes.
         assert((reshape_index is None) or (reshape_index in [0, -1]))
         assert((reshape_shape is None) or (np.prod(reshape_shape) == layer_sizes[reshape_index]))
-        self.reshape_index = reshape_index
-        self.reshape_shape = reshape_shape
 
-        # Initalize activation function
-        self.act_type = act_type
-        self.use_multihead = False
+        super(MultiLayerPerceptron, self).__init__()
+
+        # Note that layer_sizes specifies the dimensionality of the domains and co-domains of each
+        # layer. Specifically, the i'th element specifies the input dimension of the i'th layer,
+        # while the final element specifies the dimensionality of the co-domain of the final layer.
+        # Thus, the number of layers is one less than the length of layer_sizes.
+        self.n_layers       : int                   = len(layer_sizes) - 1;
+        self.layer_sizes    : list[int]             = layer_sizes
+
+        # Set up the affine parts of the layers.
+        self.layers            : list[torch.nn.Module] = [];
+        for k in range(self.n_layers):
+            self.layers += [torch.nn.Linear(layer_sizes[k], layer_sizes[k + 1])]
+        self.layers = torch.nn.ModuleList(self.layers)
+
+        # Now, initialize the weight matrices and bias vectors in the affine portion of each layer.
+        self.init_weight()
+
+        # Reshape input to the 1st layer or output of the last layer.
+        self.reshape_index : int        = reshape_index
+        self.reshape_shape : list[int]  = reshape_shape
+
+        # Set up the activation function. Note that we need to handle the threshold activation type
+        # separately because it requires an extra set of parameters to initialize.
+        self.act_type   : str               = act_type
         if act_type == "threshold":
-            self.act = act_dict[act_type](threshold, value)
-
-        elif act_type == "multihead":
-            self.use_multihead = True
-            if (self.n_layers > 3): # if you have more than one hidden layer
-                self.act = []
-                for i in range(self.n_layers-2):
-                    self.act += [act_dict[act_type](layer_sizes[i+1], num_heads)]
-            else:
-                self.act = [torch.nn.Identity()]  # No additional activation
-            self.act = torch.nn.ModuleList(self.fcs)
-
-        #all other activation functions initialized here
+            self.act    : torch.nn.Module   = act_dict[act_type](threshold, value)
         else:
-            self.act = act_dict[act_type]()
+            self.act    : torch.nn.Module   = act_dict[act_type]()
+
+        # All done!
         return
     
-    def forward(self, x):
+
+
+    def forward(self, x : torch.Tensor) -> torch.Tensor:
+        """
+        This function defines the forward pass through self.
+
+
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        x: A tensor holding a batch of inputs. We pass this tensor through the network's layers 
+        and then return the result. If self.reshape_index == 0 and self.reshape_shape has k
+        elements, then the final k elements of x's shape must match self.reshape_shape. 
+
+
+        
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        The image of x under the network's layers. If self.reshape_index == -1 and 
+        self.reshape_shape has k elements, then we reshape the output so that the final k elements
+        of its shape match those of self.reshape_shape.
+        """
+
+        # If the reshape_index is 0, we need to reshape x before passing it through the first 
+        # layer.
         if (self.reshape_index == 0):
-            # make sure the input has a proper shape
+            # Make sure the input has a proper shape. There is a lot going on in this line; let's
+            # break it down. If reshape_index == 0, then we need to reshape the input, x, before
+            # passing it through the layers. Let's assume that reshape_shape has k elements. Then,
+            # we need to squeeze the final k dimensions of the input, x, so that the resulting 
+            # tensor has a final dimension size that matches the input dimension size for the first
+            # layer. The check below makes sure that the final k dimensions of the input, x, match
+            # the stored reshape_shape.
             assert(list(x.shape[-len(self.reshape_shape):]) == self.reshape_shape)
-            # we use torch.Tensor.view instead of torch.Tensor.reshape,
-            # in order to avoid data copying.
+            
+            # Now that we know the final k dimensions of x have the correct shape, let's squeeze 
+            # them into 1 dimension (so that we can pass the squeezed tensor through the first 
+            # layer). To do this, we reshape x by keeping all but the last k dimensions of x, and 
+            # replacing the last k with a single dimension whose size matches the dimensionality of
+            # the domain of the first layer. Note that we use torch.Tensor.view instead of 
+            # torch.Tensor.reshape in order to avoid data copying.
             x = x.view(list(x.shape[:-len(self.reshape_shape)]) + [self.layer_sizes[self.reshape_index]])
 
-        for i in range(self.n_layers-2):
-            x = self.fcs[i](x) # apply linear layer
-            if (self.use_multihead):
-                x = self.apply_attention(self, x, i)
-            else:
-                x = self.act(x)
+        # Pass x through the network layers (except for the final one, which has no activation 
+        # function).
+        for i in range(self.n_layers - 1):
+            x : torch.Tensor = self.layers[i](x)   # apply linear layer
+            x : torch.Tensor = self.act(x)      # apply activation
 
-        x = self.fcs[-1](x)
+        # Apply the final (output) layer.
+        x = self.layers[-1](x)
 
+        # If the reshape_index is -1, then we need to reshape the output before returning. 
         if (self.reshape_index == -1):
-            # we use torch.Tensor.view instead of torch.Tensor.reshape,
-            # in order to avoid data copying.
+            # In this case, we need to split the last dimension of x, the output of the final
+            # layer, to match the reshape_shape. This is precisely what the line below does. Note
+            # that we use torch.Tensor.view instead of torch.Tensor.reshape in order to avoid data 
+            # copying. 
             x = x.view(list(x.shape[:-1]) + self.reshape_shape)
 
+        # All done!
         return x
     
-    def apply_attention(self, x, act_idx):
-        x = x.unsqueeze(1)  # Add sequence dimension for attention
-        x, _ = self.act[act_idx](x, x, x) # apply attention
-        x = x.squeeze(1)  # Remove sequence dimension
-        return x
-    
-    def init_weight(self):
+
+
+    def init_weight(self) -> None:
+        """
+        This function initializes the weight matrices and bias vectors in self's layers.
+
+        
+
+        -------------------------------------------------------------------------------------------
+        Arguments
+        -------------------------------------------------------------------------------------------
+
+        None!
+
+        
+
+        -------------------------------------------------------------------------------------------
+        Returns
+        -------------------------------------------------------------------------------------------
+
+        Nothing!
+        """
+
         # TODO(kevin): support other initializations?
-        for fc in self.fcs:
-            torch.nn.init.xavier_uniform_(fc.weight)
+        for layer in self.layers:
+            torch.nn.init.xavier_uniform_(layer.weight)
+            torch.nn.init.zeros_(layer.bias)
+        
+        # All done!
         return
 
-class Autoencoder(torch.nn.Module):
 
-    def __init__(self, physics, config):
+
+# -------------------------------------------------------------------------------------------------
+# Autoencoder class
+# -------------------------------------------------------------------------------------------------
+
+class Autoencoder(torch.nn.Module):
+    def __init__(self, physics : Physics, config : dict):
         super(Autoencoder, self).__init__()
 
-        self.qgrid_size = physics.qgrid_size
-        self.space_dim = np.prod(self.qgrid_size)
-        hidden_units = config['hidden_units']
-        n_z = config['latent_dimension']
-        self.n_z = n_z
+        self.qgrid_size                 = physics.qgrid_size;
+        self.space_dim  : np.ndarray    = np.prod(self.qgrid_size);
+        hidden_units    : int           = config['hidden_units'];
+        n_z             : int           = config['latent_dimension'];
+        self.n_z        : int           = n_z
 
         layer_sizes = [self.space_dim] + hidden_units + [n_z]
         #grab relevant initialization values from config
@@ -159,6 +336,8 @@ class Autoencoder(torch.nn.Module):
 
         return
 
+
+
     def forward(self, x):
 
         x = self.encoder(x)
@@ -166,10 +345,14 @@ class Autoencoder(torch.nn.Module):
 
         return x
     
+
+
     def export(self):
         dict_ = {'autoencoder_param': self.cpu().state_dict()}
         return dict_
     
+
+
     def load(self, dict_):
         self.load_state_dict(dict_['autoencoder_param'])
         return

--- a/src/lasdi/latent_space.py
+++ b/src/lasdi/latent_space.py
@@ -386,7 +386,7 @@ class Autoencoder(torch.nn.Module):
                             value               = value);
 
         self.decoder = MultiLayerPerceptron(
-                            latent_sizes        = layer_sizes[::-1],    # Reverses the order of the the list.
+                            layer_sizes         = layer_sizes[::-1],    # Reverses the order of the the list.
                             act_type            = act_type,
                             reshape_index       = -1,               
                             reshape_shape       = self.qgrid_size,      # We need to reshape the network output to a fom frame.

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -25,8 +25,6 @@ class ParameterSpace:
     n_param = 0
     train_space = None
     test_space = None
-    n_test = 0
-    n_train = 0
     n_init = 0
     test_grid_sizes = []
     test_meshgrid = None
@@ -44,14 +42,18 @@ class ParameterSpace:
 
         self.train_space = self.createInitialTrainSpace(self.param_list)
         self.n_init = self.train_space.shape[0]
-        self.n_train = self.n_init
 
         test_space_type = parser.getInput(['test_space', 'type'], datatype=str)
         if (test_space_type == 'grid'):
             self.test_grid_sizes, self.test_meshgrid, self.test_space = self.createTestGridSpace(self.param_list)
-            self.n_test = self.test_space.shape[0]
 
         return
+    
+    def n_train(self):
+        return self.train_space.shape[0]
+    
+    def n_test(self):
+        return self.test_space.shape[0]
     
     def createInitialTrainSpace(self, param_list):
         paramRanges = []
@@ -129,7 +131,6 @@ class ParameterSpace:
         assert(self.train_space.shape[1] == param.size)
 
         self.train_space = np.vstack((self.train_space, param))
-        self.n_train = self.train_space.shape[0]
         return
     
     def export(self):
@@ -149,7 +150,4 @@ class ParameterSpace:
         assert(self.n_init == dict_['n_init'])
         assert(self.train_space.shape[1] == self.n_param)
         assert(self.test_space.shape[1] == self.n_param)
-
-        self.n_train = self.train_space.shape[0]
-        self.n_test = self.test_space.shape[0]
         return

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -22,6 +22,7 @@ getParam1DSpace = {'list': get_1dspace_from_list,
 class ParameterSpace:
     param_list = []
     param_name = []
+    n_param = 0
     train_space = None
     test_space = None
     n_test = 0
@@ -35,6 +36,7 @@ class ParameterSpace:
         parser = InputParser(config['parameter_space'], name="param_space_input")
 
         self.param_list = parser.getInput(['parameters'], datatype=list)
+        self.n_param = len(self.param_list)
 
         self.param_name = []
         for param in self.param_list:
@@ -131,13 +133,23 @@ class ParameterSpace:
         return
     
     def export(self):
-        dict_ = {'final_param_train': self.train_space,
-                 'param_grid': self.test_space,
+        dict_ = {'train_space': self.train_space,
+                 'test_space': self.test_space,
                  'test_grid_sizes': self.test_grid_sizes,
                  'test_meshgrid': self.test_meshgrid,
                  'n_init': self.n_init}
         return dict_
     
-    def loadTrainSpace(self):
-        raise RuntimeError("ParameterSpace.loadTrainSpace is not implemented yet!")
+    def load(self, dict_):
+        self.train_space = dict_['train_space']
+        self.test_space = dict_['test_space']
+        self.test_grid_sizes = dict_['test_grid_sizes']
+        self.test_meshgrid = dict_['test_meshgrid']
+
+        assert(self.n_init == dict_['n_init'])
+        assert(self.train_space.shape[1] == self.n_param)
+        assert(self.test_space.shape[1] == self.n_param)
+
+        self.n_train = self.train_space.shape[0]
+        self.n_test = self.test_space.shape[0]
         return

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -90,7 +90,9 @@ class OfflineFOM(Physics):
         self.qdim = parser.getInput(['solution_dimension'], datatype=int)
 
         self.grid_size = parser.getInput(['grid_size'], datatype=list)
-        self.qgrid_size = [self.qdim] + self.grid_size
+        self.qgrid_size = self.grid_size
+        if (self.qdim > 1):
+            self.qgrid_size = [self.qdim] + self.qgrid_size
         assert(self.dim == len(self.grid_size))
 
         #TODO(kevin): a general file loading for spatial grid
@@ -107,3 +109,8 @@ class OfflineFOM(Physics):
     def generate_solutions(self, params):
         raise RuntimeError("OfflineFOM does not support generate_solutions!!")
         return
+
+    def export(self):
+        dict_ = {'t_grid' : self.t_grid, 'x_grid' : self.x_grid, 'dt' : self.dt}
+        return dict_
+

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -63,6 +63,7 @@ class Physics:
         X_train = None
         for k, param in enumerate(params):
             new_X = self.solve(param)
+            assert(new_X.size(0) == 1) # should contain one parameter case.
             if (X_train is None):
                 X_train = new_X
             else:
@@ -75,3 +76,34 @@ class Physics:
     def residual(self, Xhist):
         raise RuntimeError("Abstract method Physics.residual!")
         return res, res_norm
+    
+class OfflineFOM(Physics):
+    def __init__(self, param_space, cfg):
+        super().__init__(param_space, cfg)
+        self.offline = True
+
+        assert('offline_fom' in cfg)
+        from ..inputs import InputParser
+        parser = InputParser(cfg['offline_fom'], name="offline_fom_input")
+
+        self.dim = parser.getInput(['space_dimension'], datatype=int)
+        self.qdim = parser.getInput(['solution_dimension'], datatype=int)
+
+        self.grid_size = parser.getInput(['grid_size'], datatype=list)
+        self.qgrid_size = [self.qdim] + self.grid_size
+        assert(self.dim == len(self.grid_size))
+
+        #TODO(kevin): a general file loading for spatial grid
+        #             There can be unstructured grids as well.
+        self.x_grid = None
+
+        # Assume uniform time stepping for now.
+        self.nt = parser.getInput(['number_of_timesteps'], datatype=int)
+        self.dt = parser.getInput(['timestep_size'], datatype=float)
+        self.t_grid = np.linspace(0.0, (self.nt-1) * self.dt, self.nt)
+
+        return
+    
+    def generate_solutions(self, params):
+        raise RuntimeError("OfflineFOM does not support generate_solutions!!")
+        return

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -57,6 +57,7 @@ class Physics:
         params.shape[1] must match the required size of
         parameters for the specific physics.
         '''
+        assert(params.ndim == 2)
         n_param = len(params)
         print("Generating %d samples" % n_param)
 

--- a/src/lasdi/physics/__init__.py
+++ b/src/lasdi/physics/__init__.py
@@ -31,11 +31,11 @@ class Physics:
     # Set at the initialization.
     offline = False
 
-    # ParameterSpace object to parse parameters.
-    param_space = None
+    # list of parameter names to parse parameters.
+    param_name = None
 
-    def __init__(self, param_space, cfg):
-        self.param_space = param_space
+    def __init__(self, cfg, param_name=None):
+        self.param_name = param_name
         return
     
     def initial_condition(self, param):
@@ -78,8 +78,8 @@ class Physics:
         return res, res_norm
     
 class OfflineFOM(Physics):
-    def __init__(self, param_space, cfg):
-        super().__init__(param_space, cfg)
+    def __init__(self, cfg, param_name=None):
+        super().__init__(cfg, param_name)
         self.offline = True
 
         assert('offline_fom' in cfg)

--- a/src/lasdi/physics/burgers1d.py
+++ b/src/lasdi/physics/burgers1d.py
@@ -7,8 +7,11 @@ from . import Physics
 from ..fd import FDdict
 
 class Burgers1D(Physics):
-    def __init__(self, param_space, cfg):
-        super().__init__(param_space, cfg)
+    a_idx = None # parameter index for a
+    w_idx = None # parameter index for w
+
+    def __init__(self, cfg, param_name=None):
+        super().__init__(cfg, param_name)
 
         self.qdim = 1
         self.dim = 1
@@ -36,12 +39,20 @@ class Burgers1D(Physics):
 
         self.maxk = parser.getInput(['maxk'], fallback=10)
         self.convergence_threshold = parser.getInput(['convergence_threshold'], fallback=1.e-8)
+
+        if (self.param_name is not None):
+            if 'a' in self.param_name:
+                self.a_idx = self.param_name.index('a')
+            if 'w' in self.param_name:
+                self.w_idx = self.param_name.index('w')
         return
     
     def initial_condition(self, param):
-        param = self.param_space.getParameter(param)
-        a = param['a'] if 'a' in param else 1.0
-        w = param['w'] if 'w' in param else 1.0
+        a, w = 1.0, 1.0
+        if 'a' in self.param_name:
+            a = param[self.a_idx]
+        if 'w' in self.param_name:
+            w = param[self.w_idx]
 
         return a * np.exp(- self.x_grid ** 2 / 2 / w / w)
     
@@ -153,7 +164,7 @@ def main():
     # initialize parameter space and physics class
     from ..param import ParameterSpace
     param_space = ParameterSpace(config)
-    physics = Burgers1D(param_space, config['physics'])
+    physics = Burgers1D(config['physics'], param_space.param_name)
 
     # read training parameter points
     train_param_file = cfg_parser.getInput(['workflow', 'offline_greedy_sampling', 'train_param_file'], datatype=str)

--- a/src/lasdi/timing.py
+++ b/src/lasdi/timing.py
@@ -40,8 +40,22 @@ class Timer:
         return
     
     def export(self):
+        for start in self.starts:
+            if (start is not None):
+                raise RuntimeError('Timer.export: cannot export while Timer is still ticking!')
+
         param_dict = {}
         param_dict["names"] = self.names
         param_dict["calls"] = self.calls
         param_dict["times"] = self.times
         return param_dict
+    
+    def load(self, dict_):
+        self.names = dict_['names']
+        self.calls = dict_['calls']
+        self.times = dict_['times']
+
+        assert(len(self.names) == len(self.calls))
+        assert(len(self.names) == len(self.times))
+        self.starts = [None] * len(self.names)
+        return

--- a/src/lasdi/workflow.py
+++ b/src/lasdi/workflow.py
@@ -9,6 +9,7 @@ from .latent_space import Autoencoder
 from .latent_dynamics.sindy import SINDy
 from .physics.burgers1d import Burgers1D
 from .param import ParameterSpace
+from .inputs import InputParser
 
 trainer_dict = {'gplasdi': BayesianGLaSDI}
 
@@ -29,63 +30,102 @@ def main():
 
     with open(args.config_file, 'r') as f:
         config = yaml.safe_load(f)
+        cfg_parser = InputParser(config, name='main')
 
-    trainer = initialize_trainer(config)
+    use_restart = cfg_parser.getInput(['workflow', 'use_restart'], fallback=False)
+    if (use_restart):
+        restart_filename = cfg_parser.getInput(['workflow', 'restart_file'], datatype=str)
+        from os.path import dirname
+        from pathlib import Path
+        Path(dirname(restart_filename)).mkdir(parents=True, exist_ok=True)
 
-    if ('restart_file' in config):
-        restart_file = np.load(config['restart_file'], allow_pickle=True).item()
-        next_step = restart_file['next_step']
+    import os
+    if (use_restart and (os.path.isfile(restart_filename))):
+        # TODO(kevin): in long term, we should switch to hdf5 format.
+        restart_file = np.load(restart_filename, allow_pickle=True).item()
+        current_step = restart_file['next_step']
         result = restart_file['result']
     else:
-        next_step = NextStep.Initial
+        restart_file = None
+        current_step = NextStep.Initial
         result = Result.Unexecuted
+    
+    trainer, param_space, physics, latent_space, latent_dynamics = initialize_trainer(config, restart_file)
+
+    result, next_step = step(trainer, current_step, config, use_restart)
 
     if (result is Result.Fail):
         raise RuntimeError('Previous step has failed. Stopping the workflow.')
+    elif (result is Result.Success):
+        print("Previous step succeeded. Preparing for the next step.")
+        result = Result.Unexecuted
     elif (result is Result.Complete):
         print("Workflow is finished.")
-        return result
 
-    result = step(trainer, next_step, config)
+    # save restart (or final) file.
+    import time
+    date = time.localtime()
+    date_str = "{month:02d}_{day:02d}_{year:04d}_{hour:02d}_{minute:02d}"
+    date_str = date_str.format(month = date.tm_mon, day = date.tm_mday, year = date.tm_year, hour = date.tm_hour + 3, minute = date.tm_min)
+    if (use_restart):
+        # rename old restart file if exists.
+        if (os.path.isfile(restart_filename)):
+            old_timestamp = restart_file['timestamp']
+            os.rename(restart_filename, restart_filename + '.' + old_timestamp)
+        save_file = restart_filename
+    else:
+        save_file = 'lasdi_' + date_str + '.npy'
+    
+    save_dict = {'parameters': param_space.export(),
+                 'physics': physics.export(),
+                 'latent_space': latent_space.export(),
+                 'latent_dynamics': latent_dynamics.export(),
+                 'trainer': trainer.export(),
+                 'timestamp': date_str,
+                 'next_step': next_step,
+                 'result': result, # TODO(kevin): do we need to save result?
+                 }
+    
+    np.save(save_file, save_dict)
 
     return result
 
-def step(trainer, next_step, config):
-    # TODO(kevin): implement save/load workflow.
-    continue_workflow = True
+def step(trainer, next_step, config, use_restart=False):
 
     if (next_step is NextStep.Initial):
 
         result, next_step = initial_step(trainer, config)
-        if (continue_workflow):
-            result = step(trainer, next_step, config)
 
     elif (next_step is NextStep.Train):
 
         result, next_step = trainer.train()
-        if (result is Result.Complete):
-            return result
-        else:
-            assert(next_step is NextStep.RunSample)
-            result = step(trainer, next_step, config)
 
     elif (next_step is NextStep.RunSample):
 
         trainer.sample_fom()
         # TODO(kevin): currently no offline fom simulation. skip CollectSample.
         result, next_step = Result.Success, NextStep.Train
-        result = step(trainer, next_step, config)
+        # result = step(trainer, next_step, config)
 
     elif (next_step is NextStep.CollectSample):
         import warnings
         warnings.warn("Collecting sample from offline FOM simulation is not implemented yet")
+        result, next_step = Result.Success, NextStep.RunSample
 
     else:
         raise RuntimeError("Unknown next step!")
+    
+    # if fail or complete, break the loop regardless of use_restart.
+    if ((result is Result.Fail) or (result is Result.Complete)):
+        return result, next_step
+    
+    # continue the workflow if not using restart.
+    if (not use_restart):
+        result, next_step = step(trainer, next_step, config)
 
-    return result
+    return result, next_step
 
-def initialize_trainer(config):
+def initialize_trainer(config, restart_file=None):
     '''
     Initialize a LaSDI class with a latent space model according to config file.
     Currently only 'gplasdi' is available.
@@ -93,23 +133,31 @@ def initialize_trainer(config):
 
     # TODO(kevin): load parameter train space from a restart file.
     param_space = ParameterSpace(config)
+    if (restart_file is not None):
+        param_space.load(restart_file['parameters'])
 
     physics = initialize_physics(param_space, config)
     latent_space = initialize_latent_space(physics, config)
+    if (restart_file is not None):
+        latent_space.load(restart_file['latent_space'])
 
     # do we need a separate routine for latent dynamics initialization?
     ld_type = config['latent_dynamics']['type']
     assert(ld_type in config['latent_dynamics'])
     assert(ld_type in ld_dict)
     latent_dynamics = ld_dict[ld_type](latent_space.n_z, physics.nt, config['latent_dynamics'])
+    if (restart_file is not None):
+        latent_dynamics.load(restart_file['latent_dynamics'])
 
     trainer_type = config['lasdi']['type']
     assert(trainer_type in config['lasdi'])
     assert(trainer_type in trainer_dict)
 
     trainer = trainer_dict[trainer_type](physics, latent_space, latent_dynamics, config['lasdi'][trainer_type])
+    if (restart_file is not None):
+        trainer.load(restart_file['trainer'])
 
-    return trainer
+    return trainer, param_space, physics, latent_space, latent_dynamics
 
 def initialize_latent_space(physics, config):
     '''

--- a/src/lasdi/workflow.py
+++ b/src/lasdi/workflow.py
@@ -149,7 +149,7 @@ def initialize_trainer(config, restart_file=None):
     if (restart_file is not None):
         param_space.load(restart_file['parameters'])
 
-    physics = initialize_physics(param_space, config)
+    physics = initialize_physics(config, param_space.param_name)
     latent_space = initialize_latent_space(physics, config)
     if (restart_file is not None):
         latent_space.load(restart_file['latent_space'])
@@ -166,7 +166,7 @@ def initialize_trainer(config, restart_file=None):
     assert(trainer_type in config['lasdi'])
     assert(trainer_type in trainer_dict)
 
-    trainer = trainer_dict[trainer_type](physics, latent_space, latent_dynamics, config['lasdi'][trainer_type])
+    trainer = trainer_dict[trainer_type](physics, latent_space, latent_dynamics, param_space, config['lasdi'][trainer_type])
     if (restart_file is not None):
         trainer.load(restart_file['trainer'])
 
@@ -188,7 +188,7 @@ def initialize_latent_space(physics, config):
 
     return latent_space
 
-def initialize_physics(param_space, config):
+def initialize_physics(config, param_name):
     '''
     Initialize a physics FOM model according to config file.
     Currently only 'burgers1d' is available.
@@ -196,7 +196,7 @@ def initialize_physics(param_space, config):
 
     physics_cfg = config['physics']
     physics_type = physics_cfg['type']
-    physics = physics_dict[physics_type](param_space, physics_cfg)
+    physics = physics_dict[physics_type](physics_cfg, param_name)
 
     return physics
 


### PR DESCRIPTION
I added documentation (comments + doc strings + type hints + formatting) to latent_space.py

The code is functionally almost identical, save for a few minor tweaks:

    Removed the MultiHeadAttention activation function option. This isn't really an activation function, even though it is listed as such in the torch api. It is used to implement an attention layer in a transformer block. It introduces a whole new set of parameters (for the key, query, and value weight matrices) and is really designed to map finite sequences to finite sequences. I do not think it makes sense to include this in the MLP class as an activation option, so I removed it.

    Removed apply_attention. Since there is no more multiheadedattention activation option, this function should be removed.

Otherwise, all changes are cosmetic (e.g., comments + formatting).

I also fixed a small bug in gplasdi.py: np.Inf no longer exists. It is deprecated. It has been replaced with np.inf. I fixed this.
