### PR TITLE
Adding ability to define test space through convex hull

### DIFF
--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -41,6 +41,25 @@ parameter_space:
   test_space:
     type: grid
 
+#an example if we want to provide training points on exterior 
+#of region and train in convex hull of training points
+# parameter_space:
+#   parameters:
+#     - name: a
+#       min: 0.7
+#       max: 0.9
+#       test_space_type: exterior
+#       sample_size: 21
+#       list: [0.70, 0.725, 0.75, 0.800, 0.85, 0.90]
+#     - name: w
+#       min: 0.9
+#       max: 1.1
+#       test_space_type: exterior
+#       sample_size: 21
+#       list: [0.90, 0.970, 1.00, 0.925, 0.98, 1.10]
+#   test_space:
+#     type: hull
+
 latent_space:
   type: ae
   ae:

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -6,7 +6,7 @@ lasdi:
     lr: 0.001
     max_iter: 28000
     n_iter: 2000
-    max_greedy_iter: 8000
+    max_greedy_iter: 28000
     ld_weight: 0.1
     coef_weight: 1.e-6
     path_checkpoint: checkpoint

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -1,12 +1,26 @@
+# lasdi:
+#   type: gplasdi
+#   gplasdi:
+#     # device: mps
+#     n_samples: 20
+#     lr: 0.001
+#     max_iter: 28000
+#     n_iter: 2000
+#     max_greedy_iter: 8000
+#     ld_weight: 0.1
+#     coef_weight: 1.e-6
+#     path_checkpoint: checkpoint
+#     path_results: results
+
 lasdi:
   type: gplasdi
   gplasdi:
     # device: mps
     n_samples: 20
     lr: 0.001
-    max_iter: 28000
+    max_iter: 10000
     n_iter: 2000
-    max_greedy_iter: 28000
+    max_greedy_iter: 8000
     ld_weight: 0.1
     coef_weight: 1.e-6
     path_checkpoint: checkpoint
@@ -41,22 +55,24 @@ parameter_space:
   test_space:
     type: grid
 
-#an example if we want to provide training points on exterior 
-#of region and train in convex hull of training points
+## An example if we want to provide training points on exterior 
+## of region and train in convex hull of training points
 # parameter_space:
 #   parameters:
 #     - name: a
 #       min: 0.7
 #       max: 0.9
-#       test_space_type: exterior
+#       test_space_type: list
 #       sample_size: 21
 #       list: [0.70, 0.725, 0.75, 0.800, 0.85, 0.90]
+#       log_scale: false
 #     - name: w
 #       min: 0.9
 #       max: 1.1
-#       test_space_type: exterior
+#       test_space_type: list
 #       sample_size: 21
 #       list: [0.90, 0.970, 1.00, 0.925, 0.98, 1.10]
+#       log_scale: false
 #   test_space:
 #     type: hull
 

--- a/examples/burgers1d.yml
+++ b/examples/burgers1d.yml
@@ -1,24 +1,10 @@
-# lasdi:
-#   type: gplasdi
-#   gplasdi:
-#     # device: mps
-#     n_samples: 20
-#     lr: 0.001
-#     max_iter: 28000
-#     n_iter: 2000
-#     max_greedy_iter: 8000
-#     ld_weight: 0.1
-#     coef_weight: 1.e-6
-#     path_checkpoint: checkpoint
-#     path_results: results
-
 lasdi:
   type: gplasdi
   gplasdi:
     # device: mps
     n_samples: 20
     lr: 0.001
-    max_iter: 10000
+    max_iter: 28000
     n_iter: 2000
     max_greedy_iter: 8000
     ld_weight: 0.1

--- a/src/lasdi/gplasdi.py
+++ b/src/lasdi/gplasdi.py
@@ -138,7 +138,7 @@ class BayesianGLaSDI:
         else:
             self.device = 'cpu'
 
-        self.best_loss = np.inf
+        self.best_loss = np.Inf
         self.best_coefs = None
         self.restart_iter = 0
 

--- a/src/lasdi/gplasdi.py
+++ b/src/lasdi/gplasdi.py
@@ -138,7 +138,7 @@ class BayesianGLaSDI:
         else:
             self.device = 'cpu'
 
-        self.best_loss = np.Inf
+        self.best_loss = np.inf
         self.best_coefs = None
         self.restart_iter = 0
 
@@ -163,6 +163,11 @@ class BayesianGLaSDI:
         n_train = ps.n_train()
         ld = self.latent_dynamics
 
+        self.training_loss = []
+        self.ae_loss = []
+        self.ld_loss = []
+        self.coef_loss = []
+
         '''
             determine number of iterations.
             Perform n_iter iterations until overall iterations hit max_iter.
@@ -183,6 +188,11 @@ class BayesianGLaSDI:
             max_coef = np.abs(coefs).max()
 
             loss = loss_ae + self.ld_weight * loss_ld / n_train + self.coef_weight * loss_coef / n_train
+
+            self.training_loss.append(loss.item())
+            self.ae_loss.append(loss_ae.item())
+            self.ld_loss.append(loss_ld.item())
+            self.coef_loss.append(loss_coef.item())
 
             loss.backward()
             self.optimizer.step()
@@ -267,7 +277,8 @@ class BayesianGLaSDI:
         dict_ = {'X_train': self.X_train, 'X_test': self.X_test, 'lr': self.lr, 'n_iter': self.n_iter,
                  'n_samples' : self.n_samples, 'best_coefs': self.best_coefs, 'max_iter': self.max_iter,
                  'max_iter': self.max_iter, 'ld_weight': self.ld_weight, 'coef_weight': self.coef_weight,
-                 'restart_iter': self.restart_iter, 'timer': self.timer.export(), 'optimizer': self.optimizer.state_dict()
+                 'restart_iter': self.restart_iter, 'timer': self.timer.export(), 'optimizer': self.optimizer.state_dict(),
+                 'training_loss' : self.training_loss, 'ae_loss' : self.ae_loss, 'ld_loss' : self.ld_loss, 'coeff_loss' : self.coef_loss
                  }
         return dict_
     

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -155,7 +155,7 @@ class ParameterSpace:
             - max
             - sample_size
             - list
-            - log_scale false
+            - log_scale
             
         -------------------------------------------------------------------------------------------
         Returns
@@ -208,7 +208,7 @@ class ParameterSpace:
             - max
             - sample_size
             - list
-            - log_scale false
+            - log_scale
             
         -------------------------------------------------------------------------------------------
         Returns

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -76,11 +76,11 @@ class ParameterSpace:
     def createInitialTrainSpaceForHull(self, param_list):
         '''
         Concatenates the provided lists of training points into a 2D array.
-        param_list: A list of parameter dictionaries
+            param_list: A list of parameter dictionaries
     
-        output: mesh_grid
-            - np.array of size [d, k], where d is the number of points provided on the exterior of
-              the training space and k is the number of parameters (k == len(param_list)).
+            Output: mesh_grid
+                - np.array of size [d, k], where d is the number of points provided on the exterior of
+                  the training space and k is the number of parameters (k == len(param_list)).
         '''
 
         paramRanges = []
@@ -114,9 +114,9 @@ class ParameterSpace:
     def createTestGridSpaceForHull(self, param_list):
         '''
         Builds an initial uniform grid for the testing parameters when the test_space is 'hull'. 
-        param_list: A list of parameter dictionaries
+            param_list: A list of parameter dictionaries
     
-        output: gridSizes, mesh_grids, param_grid
+            Output: gridSizes, mesh_grids, param_grid
         '''
 
         paramRanges = []
@@ -135,9 +135,9 @@ class ParameterSpace:
         This function builds an initial uniform grid for the testing parameters, and then
         returns any testing points which are within the convex hull of the provided
         training parameters.
-        param_list: A list of parameter dictionaries
+            param_list: A list of parameter dictionaries
     
-        output: gridSizes, mesh_grids, test_space
+            Output: gridSizes, mesh_grids, test_space
         '''
 
         # Get the initial uniform grid over the training parameters

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -76,12 +76,17 @@ class ParameterSpace:
     def createInitialTrainSpaceForHull(self, param_list):
         '''
             Concatenates the provided lists of training points into a 2D array.
-            
-            param_list: A list of parameter dictionaries
+
+            Arguments
+            ---------
+            param_list : :obj:`list(dict)`
+                A list of parameter dictionaries
     
-            Output: mesh_grid
-                - np.array of size [d, k], where d is the number of points provided on the exterior of
-                  the training space and k is the number of parameters (k == len(param_list)).
+            Returns
+            -------
+            mesh_grids : :obj:`numpy.array`
+                np.array of size [d, k], where d is the number of points provided on the exterior of
+                the training space and k is the number of parameters (k == len(param_list)).
         '''
 
         paramRanges = []
@@ -115,10 +120,21 @@ class ParameterSpace:
     def createTestGridSpaceForHull(self, param_list):
         '''
             Builds an initial uniform grid for the testing parameters when the test_space is 'hull'. 
-            
-            param_list: A list of parameter dictionaries
+
+            Arguments
+            ---------
+            param_list : :obj:`list(dict)`
+                A list of parameter dictionaries
     
-            Output: gridSizes, mesh_grids, param_grid
+            Returns
+            -------
+            gridSizes : :obj:`list(Nx)`
+                A list containing the number of elements on the grid in each parameter.
+            mesh_grids : :obj:`numpy.array`
+                tuple of numpy nd arrays, corresponding to each parameter.
+                Dimension of the array equals to the number of parameters.
+            param_grid : :obj:`numpy.array`
+                numpy 2d array of size (grid size x number of parameters).
         '''
 
         paramRanges = []
@@ -138,9 +154,21 @@ class ParameterSpace:
             returns any testing points which are within the convex hull of the provided
             training parameters.
 
-            param_list: A list of parameter dictionaries
+            Arguments
+            ---------
+            param_list : :obj:`list(dict)`
+                A list of parameter dictionaries
     
-            Output: gridSizes, mesh_grids, test_space
+            Returns
+            -------
+            gridSizes : :obj:`list(Nx)`
+                A list containing the number of elements on the grid in each parameter.
+            mesh_grids : :obj:`numpy.array`
+                tuple of numpy nd arrays, corresponding to each parameter.
+                Dimension of the array equals to the number of parameters.
+            test_space : :obj:`numpy.array`
+                numpy 2d array of size [d, k], where d is the number of testing points within
+                convex hull of the training space and k is the number of parameters (k == len(param_list)).
         '''
 
         # Get the initial uniform grid over the training parameters

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -75,7 +75,8 @@ class ParameterSpace:
     
     def createInitialTrainSpaceForHull(self, param_list):
         '''
-        Concatenates the provided lists of training points into a 2D array.
+            Concatenates the provided lists of training points into a 2D array.
+            
             param_list: A list of parameter dictionaries
     
             Output: mesh_grid
@@ -113,7 +114,8 @@ class ParameterSpace:
     
     def createTestGridSpaceForHull(self, param_list):
         '''
-        Builds an initial uniform grid for the testing parameters when the test_space is 'hull'. 
+            Builds an initial uniform grid for the testing parameters when the test_space is 'hull'. 
+            
             param_list: A list of parameter dictionaries
     
             Output: gridSizes, mesh_grids, param_grid
@@ -132,9 +134,10 @@ class ParameterSpace:
     
     def createTestHullSpace(self, param_list):
         '''
-        This function builds an initial uniform grid for the testing parameters, and then
-        returns any testing points which are within the convex hull of the provided
-        training parameters.
+            This function builds an initial uniform grid for the testing parameters, and then
+            returns any testing points which are within the convex hull of the provided
+            training parameters.
+
             param_list: A list of parameter dictionaries
     
             Output: gridSizes, mesh_grids, test_space

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -74,41 +74,20 @@ class ParameterSpace:
         return self.createHyperGridSpace(mesh_grids)
     
     def createInitialTrainSpaceForHull(self, param_list):
+        '''
+        Concatenates the provided lists of training points into a 2D array.
+        param_list: A list of parameter dictionaries
+    
+        output: mesh_grid
+            - np.array of size [d, k], where d is the number of points provided on the exterior of
+              the training space and k is the number of parameters (k == len(param_list)).
+        '''
 
-        """
-        If test_space is 'hull', then the provided training parameters must be 
-        points on the exterior of our training space. This function concatenates the provided 
-        training points into a 2D array.
-
-        -------------------------------------------------------------------------------------------
-        Arguments
-        -------------------------------------------------------------------------------------------
-        
-        param_list: A list of parameter dictionaries. Each entry should be a dictionary with the 
-        following keys:
-            - name
-            - min
-            - max
-            - sample_size
-            - list
-            - log_scale false
-            
-        -------------------------------------------------------------------------------------------
-        Returns
-        -------------------------------------------------------------------------------------------
-        
-        A 2d array of shape (d, k), where d is the number of points provided on the exterior of
-        the training space and k is the number of parameters (k == len(param_list)).
-        """
-
-        #A list we will use to store all of the provided training points.
         paramRanges = []
 
         for k, param in enumerate(param_list):
 
-            # Fetch the training points associated with each parameter which are given by a list.
             _, paramRange = getParam1DSpace['list'](param)
-            # Store the training points into the list.
             paramRanges += [paramRange]
 
             if k > 0:
@@ -117,7 +96,6 @@ class ParameterSpace:
                                                             'must have same length when test_space is \'hull\'.')
                 
         
-        # Stack all the provided training points into an array.
         mesh_grids = np.vstack((paramRanges)).T
         return mesh_grids
     
@@ -134,46 +112,12 @@ class ParameterSpace:
         return gridSizes, mesh_grids, self.createHyperGridSpace(mesh_grids)
     
     def createTestGridSpaceForHull(self, param_list):
-        """
-        This function sets up an initial grid for the testing parameters when the test_space is 
-        'hull'. Here, we form a uniform grid over the given training parameters based on the 
-        provided min and max values of each parameter and specified number of samples. The function
-        'createTestSpaceFromHull' will later be used to keep testing point which are in the
-        convex hull of training points.
-
-        This function is similar to the function 'createTestGridSpace', except we do not specify 
-        the 'test_space_type' value for any parameter.
-
-        -------------------------------------------------------------------------------------------
-        Arguments
-        -------------------------------------------------------------------------------------------
-        
-        param_list: A list of parameter dictionaries. Each entry should be a dictionary with the 
-        following keys:
-            - name
-            - min
-            - max
-            - sample_size
-            - list
-            - log_scale
-            
-        -------------------------------------------------------------------------------------------
-        Returns
-        -------------------------------------------------------------------------------------------
-        
-        A three element tuple. 
-        
-        The first is a list whose i'th element specifies the number of distinct values of the i'th 
-        parameter we consider (this is the length of the i'th element of "paramRanges" below).
-
-        The second is a a tuple of k numpy ndarrays (where k = len(param_list)), the i'th one of 
-        which is a k-dimensional array with shape (N0, ... , N{k - 1}), where Ni = 
-        param_list[i].size whose i(0), ... , i(k - 1) element specifies the value of the i'th 
-        parameter in the i(0), ... , i(k - 1)'th unique combination of parameter values.
-
-        The third one is a 2d array of parameter values. It has shape (M, k), where 
-        M = \prod_{i = 0}^{k - 1} param_list[i].size. 
-        """
+        '''
+        Builds an initial uniform grid for the testing parameters when the test_space is 'hull'. 
+        param_list: A list of parameter dictionaries
+    
+        output: gridSizes, mesh_grids, param_grid
+        '''
 
         paramRanges = []
         gridSizes = []
@@ -187,47 +131,14 @@ class ParameterSpace:
         return gridSizes, mesh_grids, self.createHyperGridSpace(mesh_grids)
     
     def createTestHullSpace(self, param_list):
-        """
-        This function sets up an initial grid for the testing parameters when the test_space is 
-        'hull'. Here, we form a uniform grid over the giving training parameters based on the 
-        provided min and max values of each parameter and specified number of samples. The function
-        'createTestSpaceFromHull' will later be used to only keep values of this grid which are in
-        the convex hull of our training parameters.
-
-        This function is similar to the function 'createTestGridSpace', except we do not specify 
-        the 'test_space_type' value for any parameter.
-
-        -------------------------------------------------------------------------------------------
-        Arguments
-        -------------------------------------------------------------------------------------------
-        
-        param_list: A list of parameter dictionaries. Each entry should be a dictionary with the 
-        following keys:
-            - name
-            - min
-            - max
-            - sample_size
-            - list
-            - log_scale
-            
-        -------------------------------------------------------------------------------------------
-        Returns
-        -------------------------------------------------------------------------------------------
-        
-        A three element tuple. 
-        
-        The first is a list whose i'th element specifies the number of distinct values of the i'th 
-        parameter we consider (this is the length of the i'th element of "paramRanges" below).
-
-        The second is a a tuple of k numpy ndarrays (where k = len(param_list)), the i'th one of 
-        which is a k-dimensional array with shape (N0, ... , N{k - 1}), where Ni = 
-        param_list[i].size whose i(0), ... , i(k - 1) element specifies the value of the i'th 
-        parameter in the i(0), ... , i(k - 1)'th unique combination of parameter values.
-
-        The third one is a 2d array of parameter values. It has shape (M, k), where M is the
-        number of testing points after removing points outside the convex hull of training 
-        parameters. 
-        """
+        '''
+        This function builds an initial uniform grid for the testing parameters, and then
+        returns any testing points which are within the convex hull of the provided
+        training parameters.
+        param_list: A list of parameter dictionaries
+    
+        output: gridSizes, mesh_grids, test_space
+        '''
 
         # Get the initial uniform grid over the training parameters
         gridSizes, mesh_grids, test_space = self.createTestGridSpaceForHull(param_list)

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -90,8 +90,9 @@ class ParameterSpace:
         return gridSizes, mesh_grids, self.createHyperGridSpace(mesh_grids)
     
     def createTestSpaceFromHull(self, param_list):
-        #get the initial over the parameters
+        #get the initial grid over the parameters
         gridSizes, mesh_grids, test_space = self.createTestGridSpace(self.param_list)
+
         hull = ConvexHull(test_space)
         hull_path = Path( hull.points[hull.vertices] ) #note: Path only works in 2D
 

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -48,15 +48,19 @@ class ParameterSpace:
         for param in self.param_list:
             self.param_name += [param['name']]
 
-        self.train_space = self.createInitialTrainSpace(self.param_list)
-        self.train_space = self.createInitialTrainSpaceForHull(self.param_list)
-        self.n_init = self.train_space.shape[0]
+        # self.train_space = self.createInitialTrainSpace(self.param_list)
+        # self.train_space = self.createInitialTrainSpaceForHull(self.param_list)
+        # self.n_init = self.train_space.shape[0]
 
         test_space_type = parser.getInput(['test_space', 'type'], datatype=str)
         if (test_space_type == 'grid'):
+            self.train_space = self.createInitialTrainSpace(self.param_list)
+            self.n_init = self.train_space.shape[0]
             self.test_grid_sizes, self.test_meshgrid, self.test_space = self.createTestGridSpace(self.param_list)
         if (test_space_type == 'hull'):
             assert self.n_param == 2, 'Convex hull only implemented for 2D parameter space!'
+            self.train_space = self.createInitialTrainSpaceForHull(self.param_list)
+            self.n_init = self.train_space.shape[0]
             self.test_grid_sizes, self.test_meshgrid, self.test_space = self.createTestSpaceFromHull(self.param_list)
 
         return

--- a/src/lasdi/param.py
+++ b/src/lasdi/param.py
@@ -128,7 +128,7 @@ class ParameterSpace:
     
             Returns
             -------
-            gridSizes : :obj:`list(Nx)`
+            gridSizes : :obj:`list(int)`
                 A list containing the number of elements on the grid in each parameter.
             mesh_grids : :obj:`numpy.array`
                 tuple of numpy nd arrays, corresponding to each parameter.
@@ -161,7 +161,7 @@ class ParameterSpace:
     
             Returns
             -------
-            gridSizes : :obj:`list(Nx)`
+            gridSizes : :obj:`list(int)`
                 A list containing the number of elements on the grid in each parameter.
             mesh_grids : :obj:`numpy.array`
                 tuple of numpy nd arrays, corresponding to each parameter.


### PR DESCRIPTION
This PR adds two things:

1. We introduce the ability to define training points on the exterior some region of interest. To define the testing points, we  first form a uniform grid over the training parameters and then remove all testing points which are not in the convex hull of the training parameters. 
This adds the new 'exterior' option for the test_space_type and requires that _all_ of the training points are given as lists. This is useful if we are not interested in sampling from a rectangular grid, and instead have a specific region of interest for the problem. The post-processing files need to be changed.

2. We now track the training loss and each term of the loss function. These losses are saved with the final output file after training.

