### PR TITLE
Change `coefs` definition for SINDy when using torch

### DIFF
--- a/src/lasdi/latent_dynamics/sindy.py
+++ b/src/lasdi/latent_dynamics/sindy.py
@@ -46,7 +46,7 @@ class SINDy(LatentDynamics):
             if (numpy):
                 coefs = np.zeros([n_train, self.ncoefs])
             else:
-                coefs = torch.Tensor([n_train, self.ncoefs])
+                coefs = torch.zeros([n_train, self.ncoefs])
             loss_sindy, loss_coef = 0.0, 0.0
 
             for i in range(n_train):


### PR DESCRIPTION
A small change for the preallocation of SINDy coefficients `coefs` when using torch. As defined, `torch.Tensor([n_train, self.ncoefs])` returns a tensor with two entries which are `n_train` and `self.ncoefs`. This small change makes it so that we define a tensor of size `n_train` by `self.ncoefs`

